### PR TITLE
Add benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.5",
     "@types/node-fetch": "^2.5.7",
+    "micro-bmark": "^0.1.2",
     "chai": "^4.2.0",
     "mocha": "^8.1.3",
     "ts-node": "^9.0.0",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,14 @@
+const { SecretKey, verify } = require("@chainsafe/blst");
+const { run, mark } = require("micro-bmark");
+const { randomBytes } = require("crypto");
+const rand = () => new Uint8Array(randomBytes(32));
+
+run(async () => {
+  const sk = SecretKey.fromKeygen(rand());
+  const msg = randomBytes(32);
+  const pk = sk.toPublicKey();
+  const sig = sk.sign(msg);
+  await mark("getPublicKey", () => SecretKey.fromKeygen(rand()).toPublicKey());
+  await mark("sign", () => sk.sign(rand()));
+  await mark("verify", () => verify(msg, pk, sig));
+});

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,4 +1,4 @@
-const { SecretKey, verify } = require("@chainsafe/blst");
+const { SecretKey, verify } = require("../src/lib");
 const { run, mark } = require("micro-bmark");
 const { randomBytes } = require("crypto");
 const rand = () => new Uint8Array(randomBytes(32));


### PR DESCRIPTION
Hi folks. I've created similar BLS library in pure js, and was looking for how much faster is this one.

`micro-bmark` is zero-dep benchmark suite that produces nice output:

```
getPublicKey x 6203 ops/sec @ 161μs/op
sign x 1329 ops/sec @ 751μs/op
verify x 584 ops/sec @ 1ms/op
```