### PR TITLE
Re-org lib

### DIFF
--- a/benchmark/batchVerify.ts
+++ b/benchmark/batchVerify.ts
@@ -18,7 +18,6 @@ const msg = Buffer.from("Mr F was here");
         const sig = sk.sign(msg);
         return { pk, sig };
       },
-      beforeEach: (arg) => arg,
       run: ({ pk, sig }) => {
         for (let j = 0; j < i; j++) {
           bls.verify(msg, pk, sig);
@@ -38,7 +37,6 @@ const msg = Buffer.from("Mr F was here");
           sigs: Array.from({ length: i }, (_, i) => sig),
         };
       },
-      beforeEach: (arg) => arg,
       run: ({ msgs, pks, sigs }) => {
         bls.verifyMultipleAggregateSignatures(msgs, pks, sigs);
       },

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -7,8 +7,7 @@ import {
   Pairing,
 } from "../src/bindings";
 import {
-  AggregatePublicKey,
-  AggregateSignature,
+  aggregateSignatures,
   fastAggregateVerify,
   PublicKey,
   SecretKey,
@@ -270,19 +269,19 @@ const msg = Buffer.from("Mr F was here");
   });
 
   for (const n of [32, 128, 512]) {
-    await runBenchmark<{ pks: AggregatePublicKey[]; sig: Signature }>({
+    await runBenchmark<{ pks: PublicKey[]; sig: Signature }>({
       id: `BLS agg verif of 1 msg by ${n} pubkeys`,
       before: () => {
-        const pks: AggregatePublicKey[] = [];
+        const pks: PublicKey[] = [];
         const sigs: Signature[] = [];
 
         for (let i = 0; i < n; i++) {
           const sk = SecretKey.fromKeygen(Buffer.alloc(32, i));
-          pks.push(sk.toAggregatePublicKey());
+          pks.push(sk.toPublicKey());
           sigs.push(sk.sign(msg));
         }
 
-        const sig = AggregateSignature.fromSignatures(sigs).toSignature();
+        const sig = aggregateSignatures(sigs);
         return { pks, sig };
       },
       run: ({ pks, sig }) => {

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -178,7 +178,6 @@ const msg = Buffer.from("Mr F was here");
       const sig = sk.sign(msg);
       return { pk, sig };
     },
-    beforeEach: (arg) => arg,
     run: ({ pk, sig }) => {
       verify(msg, pk, sig);
     },
@@ -200,7 +199,6 @@ const msg = Buffer.from("Mr F was here");
         const sig = AggregateSignature.fromSignatures(sigs).toSignature();
         return { pks, sig };
       },
-      beforeEach: (arg) => arg,
       run: ({ pks, sig }) => {
         fastAggregateVerify(msg, pks, sig);
       },

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -22,44 +22,6 @@ const hashOrEncode = true;
 const msg = Buffer.from("Mr F was here");
 
 (async function () {
-  // Benchmark the cost of having pubkeys cached as P1 or P1_Affine
-
-  for (const aggCount of [128, 256]) {
-    const iArr = Array.from({ length: aggCount }, (v, i) => i);
-    const sks = iArr.map((i) => {
-      const sk = new blst.SecretKey();
-      sk.from_bendian(Buffer.alloc(32, i + 1));
-      return sk;
-    });
-
-    await runBenchmark<InstanceType<typeof blst.P1>[]>({
-      id: `BLS aggregate ${aggCount} from P1[] with .add`,
-      before: () => sks.map((sk) => new blst.P1(sk)),
-      run: (pks) => {
-        const agg = new blst.P1();
-        for (const pk of pks) agg.add(pk);
-      },
-    });
-
-    await runBenchmark<InstanceType<typeof blst.P1_Affine>[]>({
-      id: `BLS aggregate ${aggCount} from P1_Aff[] with .add`,
-      before: () => sks.map((sk) => new blst.P1(sk).to_affine()),
-      run: (pks) => {
-        const agg = new blst.P1();
-        for (const pk of pks) agg.add(pk);
-      },
-    });
-
-    await runBenchmark<InstanceType<typeof blst.P1_Affine>[]>({
-      id: `BLS aggregate ${aggCount} from P1_Aff[] with .aggregate`,
-      before: () => sks.map((sk) => new blst.P1(sk).to_affine()),
-      run: (pks) => {
-        const agg = new blst.P1();
-        for (const pk of pks) agg.aggregate(pk);
-      },
-    });
-  }
-
   await runBenchmark({
     id: "Scalar multiplication G1 (255-bit, constant-time)",
     before: () => {},
@@ -225,7 +187,51 @@ const msg = Buffer.from("Mr F was here");
         before: () => {},
         run: () => p.is_inf(),
       });
+
+      await runBenchmark({
+        id: `${id} dup`,
+        before: () => {},
+        run: () => p.dup(),
+      });
     }
+  }
+
+  // Benchmark the cost of having pubkeys cached as P1 or P1_Affine
+
+  for (const aggCount of [128, 256]) {
+    const iArr = Array.from({ length: aggCount }, (v, i) => i);
+    const sks = iArr.map((i) => {
+      const sk = new blst.SecretKey();
+      sk.from_bendian(Buffer.alloc(32, i + 1));
+      return sk;
+    });
+
+    await runBenchmark<InstanceType<typeof blst.P1>[]>({
+      id: `BLS aggregate ${aggCount} from P1[] with .add`,
+      before: () => sks.map((sk) => new blst.P1(sk)),
+      run: (pks) => {
+        const agg = new blst.P1();
+        for (const pk of pks) agg.add(pk);
+      },
+    });
+
+    await runBenchmark<InstanceType<typeof blst.P1_Affine>[]>({
+      id: `BLS aggregate ${aggCount} from P1_Aff[] with .add`,
+      before: () => sks.map((sk) => new blst.P1(sk).to_affine()),
+      run: (pks) => {
+        const agg = new blst.P1();
+        for (const pk of pks) agg.add(pk);
+      },
+    });
+
+    await runBenchmark<InstanceType<typeof blst.P1_Affine>[]>({
+      id: `BLS aggregate ${aggCount} from P1_Aff[] with .aggregate`,
+      before: () => sks.map((sk) => new blst.P1(sk).to_affine()),
+      run: (pks) => {
+        const agg = new blst.P1();
+        for (const pk of pks) agg.aggregate(pk);
+      },
+    });
   }
 
   // BLS lib

--- a/benchmark/index.ts
+++ b/benchmark/index.ts
@@ -206,12 +206,22 @@ const msg = Buffer.from("Mr F was here");
       return sk;
     });
 
+    // Fastest than using .dup()
     await runBenchmark<InstanceType<typeof blst.P1>[]>({
       id: `BLS aggregate ${aggCount} from P1[] with .add`,
       before: () => sks.map((sk) => new blst.P1(sk)),
       run: (pks) => {
         const agg = new blst.P1();
         for (const pk of pks) agg.add(pk);
+      },
+    });
+
+    await runBenchmark<InstanceType<typeof blst.P1>[]>({
+      id: `BLS aggregate ${aggCount} from P1[] with .add add .dup first`,
+      before: () => sks.map((sk) => new blst.P1(sk)),
+      run: (pks) => {
+        const agg = pks[0].dup();
+        for (const pk of pks.slice(1)) agg.add(pk);
       },
     });
 
@@ -224,6 +234,7 @@ const msg = Buffer.from("Mr F was here");
       },
     });
 
+    // This is way more expensive because .aggregate does a group check on each key
     await runBenchmark<InstanceType<typeof blst.P1_Affine>[]>({
       id: `BLS aggregate ${aggCount} from P1_Aff[] with .aggregate`,
       before: () => sks.map((sk) => new blst.P1(sk).to_affine()),

--- a/benchmark/multithread.ts
+++ b/benchmark/multithread.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import * as bls from "../src/lib";
-import { BlsMultiThreadNaive } from "../test/multithread/naive";
-import { warmUpWorkers } from "../test/multithread/naive/utils";
+import { BlsMultiThreadNaive } from "../test/unit/multithread/naive";
+import { warmUpWorkers } from "../test/unit/multithread/naive/utils";
 import { runBenchmark } from "./runner";
 
 (async function () {
@@ -41,7 +41,6 @@ import { runBenchmark } from "./runner";
       const serie = await runBenchmark({
         id: "BLS batch verify",
         before: () => {},
-        beforeEach: () => {},
         run: () => {
           for (let j = 0; j < workers; j++) {
             bls.verifyMultipleAggregateSignatures(msgs, pks, sigs);
@@ -53,7 +52,6 @@ import { runBenchmark } from "./runner";
       const parallel = await runBenchmark({
         id: "BLS batch verify multithread naive",
         before: () => {},
-        beforeEach: () => {},
         run: async () => {
           await Promise.all(
             Array.from({ length: workers }, (_, i) => i).map(() =>
@@ -94,7 +92,6 @@ import { runBenchmark } from "./runner";
       const serie = await runBenchmark({
         id: "BLS verify",
         before: () => {},
-        beforeEach: () => {},
         run: () => {
           for (let i = 0; i < workers; i++) {
             bls.verify(msg, pk, sig);
@@ -106,7 +103,6 @@ import { runBenchmark } from "./runner";
       const parallel = await runBenchmark({
         id: "BLS verify multithread naive",
         before: () => {},
-        beforeEach: () => {},
         run: async () => {
           await Promise.all(
             Array.from({ length: workers }, (_, i) => i).map(() =>

--- a/benchmark/multithread.ts
+++ b/benchmark/multithread.ts
@@ -19,17 +19,11 @@ import { runBenchmark } from "./runner";
   await warmUpWorkers(pool);
 
   console.log("Preparing test data...");
-  const msgs: Uint8Array[] = [];
-  const sks: bls.SecretKey[] = [];
-  const pks: bls.PublicKey[] = [];
-  const sigs: bls.Signature[] = [];
+  const sets: bls.SignatureSet[] = [];
   for (let i = 0; i < sigCount; i++) {
     const msg = Buffer.alloc(32, i);
     const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, i));
-    msgs.push(msg);
-    sks.push(sk);
-    pks.push(sk.toPublicKey());
-    sigs.push(sk.sign(msg));
+    sets.push({ msg, pk: sk.toPublicKey(), sig: sk.sign(msg) });
   }
 
   // BLS batch verify
@@ -43,7 +37,7 @@ import { runBenchmark } from "./runner";
         before: () => {},
         run: () => {
           for (let j = 0; j < workers; j++) {
-            bls.verifyMultipleAggregateSignatures(msgs, pks, sigs);
+            bls.verifyMultipleAggregateSignatures(sets);
           }
         },
         maxMs,
@@ -55,7 +49,7 @@ import { runBenchmark } from "./runner";
         run: async () => {
           await Promise.all(
             Array.from({ length: workers }, (_, i) => i).map(() =>
-              pool.verifyMultipleAggregateSignatures(msgs, pks, sigs)
+              pool.verifyMultipleAggregateSignatures(sets)
             )
           );
         },

--- a/benchmark/multithread.ts
+++ b/benchmark/multithread.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import * as bls from "../src/lib";
-import { BlsMultiThreadNaive } from "../test/unit/multithread/naive";
-import { warmUpWorkers } from "../test/unit/multithread/naive/utils";
+import { BlsMultiThreadNaive } from "../test/multithread/naive";
+import { warmUpWorkers } from "../test/multithread/naive/utils";
 import { runBenchmark } from "./runner";
 
 (async function () {

--- a/benchmark/multithreadOverhead.ts
+++ b/benchmark/multithreadOverhead.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import * as bls from "../src/lib";
-import { BlsMultiThreadNaive } from "../test/multithread/naive";
-import { warmUpWorkers } from "../test/multithread/naive/utils";
+import { BlsMultiThreadNaive } from "../test/unit/multithread/naive";
+import { warmUpWorkers } from "../test/unit/multithread/naive/utils";
 import { runBenchmark } from "./runner";
 
 (async function () {
@@ -31,7 +31,6 @@ import { runBenchmark } from "./runner";
       const avg = await runBenchmark({
         id: `Ping num (${workers} workers)`,
         before: () => {},
-        beforeEach: () => {},
         run: async () => {
           await Promise.all(
             Array.from({ length: workers }, (_, i) => i).map(() => pool.ping(3))
@@ -67,7 +66,6 @@ import { runBenchmark } from "./runner";
         const avg = await runBenchmark({
           id: `Receive msg ${i}`,
           before: () => {},
-          beforeEach: () => {},
           run: async () => {
             await Promise.all(
               Array.from({ length: workers }, (_, i) => i).map(() =>
@@ -110,7 +108,6 @@ import { runBenchmark } from "./runner";
         const avg = await runBenchmark({
           id: `Send receive msg + serdes ${i}`,
           before: () => {},
-          beforeEach: () => {},
           run: async () => {
             await Promise.all(
               Array.from({ length: workers }, (_, i) => i).map(() =>

--- a/benchmark/multithreadOverhead.ts
+++ b/benchmark/multithreadOverhead.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import * as bls from "../src/lib";
-import { BlsMultiThreadNaive } from "../test/unit/multithread/naive";
-import { warmUpWorkers } from "../test/unit/multithread/naive/utils";
+import { BlsMultiThreadNaive } from "../test/multithread/naive";
+import { warmUpWorkers } from "../test/multithread/naive/utils";
 import { runBenchmark } from "./runner";
 
 (async function () {

--- a/benchmark/runner.ts
+++ b/benchmark/runner.ts
@@ -10,7 +10,7 @@ export async function runBenchmark<T1, T2 = T1, R = void>({
   id,
 }: {
   before: () => PromiseOptional<T1>;
-  beforeEach: (arg: T1, i: number) => PromiseOptional<T2>;
+  beforeEach?: (arg: T1, i: number) => PromiseOptional<T2>;
   run: (input: T2) => PromiseOptional<R>;
   check?: (result: R) => boolean;
   runs?: number;
@@ -24,7 +24,9 @@ export async function runBenchmark<T1, T2 = T1, R = void>({
   let start = Date.now();
   let i = 0;
   while (i++ < runs && Date.now() - start < maxMs) {
-    const input = await beforeEach(inputAll, i);
+    const input = beforeEach
+      ? await beforeEach(inputAll, i)
+      : ((inputAll as unknown) as T2);
 
     const start = process.hrtime.bigint();
     const result = await run(input);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -73,7 +73,7 @@ export class PublicKey {
     this.value = value;
   }
 
-  // Accepts both compressed and serialized
+  /** Accepts both compressed and serialized */
   static fromBytes(pkBytes: Uint8Array): PublicKey {
     return new PublicKey(new PkAffineConstructor(pkBytes));
   }
@@ -104,7 +104,7 @@ export class Signature {
     this.value = value;
   }
 
-  // Accepts both compressed and serialized
+  /** Accepts both compressed and serialized */
   static fromBytes(sigBytes: Uint8Array): Signature {
     return new Signature(new SigAffineConstructor(sigBytes));
   }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -187,8 +187,8 @@ export function aggregatePubkeys(
     throw new ErrorBLST(BLST_ERROR.EMPTY_AGGREGATE_ARRAY);
   }
 
-  const agg = pks[0].value.dup();
-  for (const pk of pks.slice(1)) {
+  const agg = new PkConstructor(); // Faster than using .dup()
+  for (const pk of pks) {
     agg.add(pk.value);
   }
 
@@ -202,8 +202,8 @@ export function aggregateSignatures(
     throw new ErrorBLST(BLST_ERROR.EMPTY_AGGREGATE_ARRAY);
   }
 
-  const agg = sigs[0].value.dup();
-  for (const pk of sigs.slice(1)) {
+  const agg = new SigConstructor(); // Faster than using .dup()
+  for (const pk of sigs) {
     agg.add(pk.value);
   }
 

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -20,19 +20,19 @@ describe("bls lib", () => {
   describe("1 msg, N pks", () => {
     const msg = Buffer.from("sample-msg");
     const sks: bls.SecretKey[] = [];
-    const pks: bls.AggregatePublicKey[] = [];
+    const pks: bls.PublicKey[] = [];
     const sigs: bls.Signature[] = [];
 
     for (let i = 0; i < n; i++) {
       const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, i));
       sks.push(sk);
-      pks.push(sk.toAggregatePublicKey());
+      pks.push(sk.toPublicKey());
       sigs.push(sk.sign(msg));
     }
 
     it("verify", () => {
       for (let i = 0; i < n; i++) {
-        const valid = bls.verify(msg, pks[i].toPublicKey(), sigs[i]);
+        const valid = bls.verify(msg, pks[i], sigs[i]);
         expect(valid).to.equal(true, `Invalid ${i}`);
       }
     });
@@ -41,45 +41,38 @@ describe("bls lib", () => {
       const valid = bls.fastAggregateVerify(
         msg,
         pks,
-        bls.AggregateSignature.fromSignatures(sigs).toSignature()
+        bls.aggregateSignatures(sigs)
       );
       expect(valid).to.equal(true);
     });
   });
 
   describe("N msgs, N pks", () => {
-    const msgs: Uint8Array[] = [];
-    const sks: bls.SecretKey[] = [];
-    const pks: bls.PublicKey[] = [];
-    const sigs: bls.Signature[] = [];
-
+    const sets: bls.SignatureSet[] = [];
     for (let i = 0; i < n; i++) {
       const msg = Buffer.alloc(32, i);
-      const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, 1));
-      msgs.push(msg);
-      sks.push(sk);
-      pks.push(sk.toPublicKey());
-      sigs.push(sk.sign(msg));
+      const sk = bls.SecretKey.fromKeygen(Buffer.alloc(32, i));
+      sets.push({ msg, pk: sk.toPublicKey(), sig: sk.sign(msg) });
     }
 
     it("verify", () => {
-      for (let i = 0; i < n; i++) {
-        const valid = bls.verify(msgs[i], pks[i], sigs[i]);
+      for (const [i, { msg, pk, sig }] of sets.entries()) {
+        const valid = bls.verify(msg, pk, sig);
         expect(valid).to.equal(true, `Invalid ${i}`);
       }
     });
 
     it("aggregateVerify", () => {
       const valid = bls.aggregateVerify(
-        msgs,
-        pks,
-        bls.AggregateSignature.fromSignatures(sigs).toSignature()
+        sets.map((s) => s.msg),
+        sets.map((s) => s.pk),
+        bls.aggregateSignatures(sets.map((s) => s.sig))
       );
       expect(valid).to.equal(true);
     });
 
     it("verifyMultipleAggregateSignatures", () => {
-      const valid = bls.verifyMultipleAggregateSignatures(msgs, pks, sigs);
+      const valid = bls.verifyMultipleAggregateSignatures(sets);
       expect(valid).to.equal(true);
     });
   });

--- a/test/multithread/naive/index.ts
+++ b/test/multithread/naive/index.ts
@@ -34,15 +34,15 @@ export class BlsMultiThreadNaive {
   }
 
   async verifyMultipleAggregateSignatures(
-    msgs: Uint8Array[],
-    pks: bls.PublicKey[],
-    sigs: bls.Signature[]
+    sets: bls.SignatureSet[]
   ): Promise<boolean> {
     return this.pool.queue((worker) =>
       worker.verifyMultipleAggregateSignatures(
-        msgs,
-        pks.map((pk) => pk.serialize()),
-        sigs.map((sig) => sig.serialize())
+        sets.map((s) => ({
+          msg: s.msg,
+          pk: s.pk.serialize(),
+          sig: s.sig.serialize(),
+        }))
       )
     );
   }

--- a/test/multithread/naive/worker.ts
+++ b/test/multithread/naive/worker.ts
@@ -7,19 +7,23 @@ const workerApi = {
   verify(msg: Uint8Array, pk: Uint8Array, sig: Uint8Array) {
     return bls.verify(
       msg,
-      bls.PublicKey.fromBytes(pk),
-      bls.Signature.fromBytes(sig)
+      bls.PublicKey.fromBytes(pk, bls.CoordType.affine),
+      bls.Signature.fromBytes(sig, bls.CoordType.affine)
     );
   },
   verifyMultipleAggregateSignatures(
-    msgs: Uint8Array[],
-    pks: Uint8Array[],
-    sigs: Uint8Array[]
+    sets: {
+      msg: Uint8Array;
+      pk: Uint8Array;
+      sig: Uint8Array;
+    }[]
   ) {
     return bls.verifyMultipleAggregateSignatures(
-      msgs,
-      pks.map(bls.PublicKey.fromBytes),
-      sigs.map(bls.Signature.fromBytes)
+      sets.map((s) => ({
+        msg: s.msg,
+        pk: bls.PublicKey.fromBytes(s.pk, bls.CoordType.affine),
+        sig: bls.Signature.fromBytes(s.sig, bls.CoordType.affine),
+      }))
     );
   },
 


### PR DESCRIPTION
Points are represented in two ways in BLST:
- affine coordinates (x,y)
- jacobian coordinates (x,y,z)

The jacobian coordinates allow to aggregate points more efficiently, so if P1 points are aggregated often (Eth2.0) you want to keep the point cached in jacobian coordinates.

---

The PublicKey class becomes a wrapper for P1 points in both coordinates representations. Internal point may be represented in affine or jacobian coordinates.

This approach allows to use this wrapper very flexibly while minimizing the coordinate conversions if used properly.

To force a instance of PublicKey to permanently switch its coordType
```ts
const pkAsAffine = new PublicKey(pk.affine)
```