### PR TITLE
v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/blst",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Typescript wrapper for supranational/blst native bindings, a highly performant BLS12-381 signature library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Breaking changes:
- AggregatePublicKey, AggregateSignature classes removed
- Different constructor and getters for PublicKey and Signature wrappers
- Different API for verifyMultipleAggregateSignatures
```ts
function verifyMultipleAggregateSignatures(signatureSets: SignatureSet[]): boolean

type SignatureSet = {
  msg: Uint8Array;
  pk: PublicKey;
  sig: Signature;
};
```