### PR TITLE
Throw for empty pks array in aggregateVerify

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -232,6 +232,10 @@ export function aggregateVerify(msgs: Uint8Array[], pks: PublicKey[], sig: Signa
   if (msgs.length !== n_elems) {
     throw new ErrorBLST(BLST_ERROR.BLST_VERIFY_FAIL);
   }
+  
+  if (n_elems.length === 0) {
+    throw new ErrorBLST(BLST_ERROR.EMPTY_AGGREGATE_ARRAY);
+  }
 
   const sigAff = sig.affine;
   const ctx = new blst.Pairing(HASH_OR_ENCODE, DST);


### PR DESCRIPTION
Throw error when attempting to aggregateVerify an empty array of pks

Fixes https://github.com/ChainSafe/blst-ts/issues/43