### PR TITLE
Use child processes in install script

### DIFF
--- a/src/scripts/downloadReleaseAsset.ts
+++ b/src/scripts/downloadReleaseAsset.ts
@@ -1,4 +1,6 @@
 import fs from "fs";
+import {pipeline} from "stream";
+import {promisify} from "util";
 import fetch from "node-fetch";
 import {ensureDirFromFilepath, PACKAGE_JSON_PATH} from "./paths";
 
@@ -19,6 +21,5 @@ export async function downloadReleaseAsset(assetName: string, binaryPath: string
     throw Error(`${res.status} ${res.statusText}`);
   }
 
-  const dest = fs.createWriteStream(binaryPath);
-  res.body.pipe(dest);
+  await promisify(pipeline)(res.body, fs.createWriteStream(binaryPath));
 }

--- a/src/scripts/testBindings.ts
+++ b/src/scripts/testBindings.ts
@@ -1,4 +1,8 @@
+import {execSync} from "child_process";
+
+// Loading prebuilt bindings may fail in any number of unhappy ways, including a segfault
+// We use child processes to catch these unrecoverable process-level errors and continue the installation process
+
 export async function testBindings(binaryPath: string): Promise<void> {
-  // eslint-disable-next-line
-  require(binaryPath);
+  execSync(`node -e 'require("${binaryPath}")'`);
 }


### PR DESCRIPTION
- split the install script in two pieces (using prebuilt bindings and building fresh bindings)
- fix download script to await the downloaded file