### PR TITLE
Use ubuntu 20.04 to build binding files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-swig:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         node: [10, 11, 12, 13, 14, 15, 16, 17, 18]
     defaults:
       run:
@@ -107,7 +107,7 @@ jobs:
 
   build-arm:
     needs: ["build-swig"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -156,7 +156,7 @@ jobs:
 
   benchmark:
     needs: ["build-swig"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -186,7 +186,7 @@ jobs:
   publish:
     needs: ["build-swig", "build", "build-arm"]
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
**Motivation**
- v0.2.7 was build with ubuntu 22.04 and it caused https://github.com/ChainSafe/blst-ts/issues/78
- See https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

**Description**
- Switch back to ubuntu 20.04 to create binding files like in v0.2.6 which works fine everywhere

Closes #78 