### PR TITLE
test(specs): aggregate and eth_aggregate_pubkeys

### DIFF
--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -114,6 +114,6 @@ export class Signature implements Serializable {
 }
 
 export function aggregatePublicKeys(keys: PublicKeyArg[]): Promise<PublicKey>;
-export function aggregatePublicKeysSync(keys: PublicKeyArg[]): PublicKey;
+export function aggregatePublicKeysSync(keys: PublicKeyArg[]): PublicKey | null;
 export function aggregateSignatures(signatures: SignatureArg[]): Promise<Signature>;
 export function aggregateSignaturesSync(signatures: SignatureArg[]): Signature;

--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -113,7 +113,7 @@ export class Signature implements Serializable {
   sigValidateSync(): void;
 }
 
-export function aggregatePublicKeys(keys: PublicKeyArg[]): Promise<PublicKey>;
+export function aggregatePublicKeys(keys: PublicKeyArg[]): Promise<PublicKey | null>;
 export function aggregatePublicKeysSync(keys: PublicKeyArg[]): PublicKey | null;
-export function aggregateSignatures(signatures: SignatureArg[]): Promise<Signature>;
-export function aggregateSignaturesSync(signatures: SignatureArg[]): Signature;
+export function aggregateSignatures(signatures: SignatureArg[]): Promise<Signature | null>;
+export function aggregateSignaturesSync(signatures: SignatureArg[]): Signature | null;

--- a/rebuild/package.json
+++ b/rebuild/package.json
@@ -18,8 +18,10 @@
     "build:clean": "npm run clean && npm run build",
     "build:debug": "node-gyp build --debug",
     "lint": "eslint --color --ext .ts lib/ test/",
+    "download-spec-tests": "ts-node test/spec/downloadTests.ts",
     "test": "yarn test:unit",
-    "test:unit": "mocha test/unit/**/*.test.ts"
+    "test:unit": "mocha test/unit/**/*.test.ts",
+    "test:spec": "mocha test/spec/**/*.test.ts"
   },
   "repository": {
     "type": "git",
@@ -45,7 +47,9 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "mocha": "^10.2.0",
+    "node-fetch": "2.6.6",
     "prettier": "^2.8.7",
+    "tar": "^6.1.14",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4"
   },

--- a/rebuild/src/addon.cc
+++ b/rebuild/src/addon.cc
@@ -156,6 +156,17 @@ bool Uint8ArrayArg::ValidateLength(size_t length1, size_t length2)
     }
     return is_valid;
 };
+bool Uint8ArrayArg::IsZeroBytes()
+{
+    for (size_t i = 0; i < ByteLength(); i++)
+    {
+        if (_data[i] != 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
 /**
  *
  *

--- a/rebuild/src/addon.h
+++ b/rebuild/src/addon.h
@@ -203,6 +203,7 @@ public:
     const uint8_t *Data();
     size_t ByteLength();
     bool ValidateLength(size_t length1, size_t length2 = 0);
+    bool IsZeroBytes();
 
 protected:
     std::string _error_prefix;

--- a/rebuild/src/public_key.cc
+++ b/rebuild/src/public_key.cc
@@ -182,18 +182,10 @@ Napi::Value PublicKey::Serialize(const Napi::CallbackInfo &info)
             : _module->_public_key_uncompressed_length);
     if (_has_jacobian)
     {
-        // if (_jacobian->is_inf())
-        // {
-        //     return scope.Escape(env.Null());
-        // }
         compressed ? _jacobian->compress(serialized.Data()) : _jacobian->serialize(serialized.Data());
     }
     else if (_has_affine)
     {
-        // if (_affine->is_inf())
-        // {
-        //     return scope.Escape(env.Null());
-        // }
         compressed ? _affine->compress(serialized.Data()) : _affine->serialize(serialized.Data());
     }
     else

--- a/rebuild/src/public_key.h
+++ b/rebuild/src/public_key.h
@@ -8,6 +8,7 @@
 class PublicKey : public BlstBase, public Napi::ObjectWrap<PublicKey>
 {
 public:
+    bool _is_zero_key;
     bool _has_jacobian;
     bool _has_affine;
     std::unique_ptr<blst::P1> _jacobian;
@@ -22,6 +23,7 @@ public:
 
     const blst::P1 *AsJacobian();
     const blst::P1_Affine *AsAffine();
+    bool NativeValidate();
 };
 
 class PublicKeyArg : public BlstBase
@@ -37,6 +39,7 @@ public:
 
     const blst::P1 *AsJacobian();
     const blst::P1_Affine *AsAffine();
+    bool NativeValidate() { return _public_key->NativeValidate(); };
 
 private:
     PublicKey *_public_key;

--- a/rebuild/test/spec/downloadTests.ts
+++ b/rebuild/test/spec/downloadTests.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import {execSync} from "node:child_process";
+import tar from "tar";
+import fetch from "node-fetch";
+import {SPEC_TEST_LOCATION, SPEC_TEST_VERSION, SPEC_TEST_REPO_URL, SPEC_TEST_TO_DOWNLOAD} from "./specTestVersioning";
+
+/* eslint-disable no-console */
+
+const specVersion = SPEC_TEST_VERSION;
+const outputDir = SPEC_TEST_LOCATION;
+const specTestsRepoUrl = SPEC_TEST_REPO_URL;
+
+const versionFile = path.join(outputDir, "version.txt");
+const existingVersion = fs.existsSync(versionFile) ? fs.readFileSync(versionFile, "utf8").trim() : "none";
+
+if (existingVersion === specVersion) {
+  console.log(`version ${specVersion} already downloaded`);
+  process.exit(0);
+} else {
+  console.log(`Downloading new version: ${specVersion} existingVersion: ${existingVersion}`);
+}
+
+if (fs.existsSync(outputDir)) {
+  console.log(`Cleaning existing version ${existingVersion} at ${outputDir}`);
+  shell(`rm -rf ${outputDir}`);
+}
+
+fs.mkdirSync(outputDir, {recursive: true});
+
+const urls = SPEC_TEST_TO_DOWNLOAD.map((test) => `${specTestsRepoUrl}/releases/download/${specVersion}/${test}.tar.gz`);
+
+downloadAndExtract(urls, outputDir)
+  .then(() => {
+    console.log("Downloads and extractions complete.");
+    fs.writeFileSync(versionFile, specVersion);
+  })
+  .catch((error) => {
+    console.error(`Error downloading test files: ${error}`);
+    process.exit(1);
+  });
+
+function shell(cmd: string): string {
+  try {
+    return execSync(cmd, {encoding: "utf8"}).trim();
+  } catch (error) {
+    console.error(`Error executing shell command: ${cmd}`);
+    throw error;
+  }
+}
+
+async function downloadAndExtract(urls: string[], outputDir: string): Promise<void> {
+  for (const url of urls) {
+    const fileName = url.split("/").pop();
+    const filePath = path.resolve(outputDir, String(fileName));
+    const response = await fetch(url);
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to download ${url}`);
+    }
+
+    await fs.promises.writeFile(filePath, response.body);
+
+    await tar.x({
+      file: filePath,
+      cwd: outputDir,
+    });
+  }
+}

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import jsYaml from "js-yaml";
 import {SPEC_TEST_LOCATION} from "./specTestVersioning";
-import {PublicKey, aggregatePublicKeysSync} from "../../lib";
+import {PublicKey, aggregatePublicKeysSync, aggregateSignaturesSync} from "../../lib";
 import {fromHex, normalizeHex} from "../utils";
 
 interface TestData {
@@ -21,7 +21,7 @@ interface TestData {
 
 const generalTestsDir = path.join(SPEC_TEST_LOCATION, "tests/general");
 const blsTestToFunctionMap: Record<string, (data: any) => any> = {
-  // aggregate,
+  aggregate,
   // aggregate_verify,
   eth_aggregate_pubkeys,
   // eth_fast_aggregate_verify,
@@ -112,10 +112,11 @@ for (const forkName of fs.readdirSync(generalTestsDir)) {
  * output: BLS Signature -- expected output, single BLS signature or empty.
  * ```
  */
-// function aggregate(input: string[]): string | null {
-//   const agg = functions.aggregateSignaturesSync(input.map((hex) => Signature.deserialize(fromHex(hex))));
-//   return toHex(agg.serialize());
-// }
+function aggregate(input: string[]): string | null {
+  const agg = aggregateSignaturesSync(input.map((hex) => fromHex(hex)));
+  if (agg === null) return agg;
+  return normalizeHex(agg.serialize());
+}
 
 /**
  * ```
@@ -142,13 +143,8 @@ for (const forkName of fs.readdirSync(generalTestsDir)) {
  * ```
  */
 function eth_aggregate_pubkeys(input: string[]): string | null {
-  // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
-  // for (const pk of input) {
-  //   if (pk === G1_POINT_AT_INFINITY) return null;
-  // }
-
   const agg = aggregatePublicKeysSync(input.map((hex) => fromHex(hex)));
-  if (agg == null) return null;
+  if (agg == null) return agg;
   return normalizeHex(agg.serialize());
 }
 

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -1,0 +1,238 @@
+import {expect} from "chai";
+import fs from "fs";
+import path from "path";
+import jsYaml from "js-yaml";
+import {SPEC_TEST_LOCATION} from "./specTestVersioning";
+import {PublicKey, aggregatePublicKeysSync} from "../../lib";
+import {fromHex, normalizeHex} from "../utils";
+
+interface TestData {
+  input: unknown;
+  output: unknown;
+}
+
+// Example full path
+// blst-ts/spec-tests/tests/general/altair/bls/eth_aggregate_pubkeys/small/eth_aggregate_pubkeys_empty_list
+
+// const G2_POINT_AT_INFINITY =
+//   "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+// const G1_POINT_AT_INFINITY =
+//   "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+const generalTestsDir = path.join(SPEC_TEST_LOCATION, "tests/general");
+const blsTestToFunctionMap: Record<string, (data: any) => any> = {
+  // aggregate,
+  // aggregate_verify,
+  eth_aggregate_pubkeys,
+  // eth_fast_aggregate_verify,
+  // fast_aggregate_verify,
+  // sign,
+  // verify,
+};
+
+for (const forkName of fs.readdirSync(generalTestsDir)) {
+  // forkName = "phase0" | "altair"
+  const blsTestsForForkDir = path.join(generalTestsDir, forkName, "bls");
+  // blsTestsForForkDir is: blst-ts/spec-tests/tests/general/altair/bls
+
+  for (const testName of fs.readdirSync(blsTestsForForkDir)) {
+    // testName = "eth_aggregate_pubkeys" | "fast_aggregate_verify" | ...
+    const testFn = blsTestToFunctionMap[testName];
+    const testsDir = path.join(blsTestsForForkDir, testName);
+    // testsDir is: blst-ts/spec-tests/tests/general/altair/bls/eth_aggregate_pubkeys
+
+    if (!testFn) continue;
+
+    describe(path.join(forkName, testName), () => {
+      before("Known testFn", () => {
+        if (!testFn) throw Error(`Unknown testFn ${testName}`);
+      });
+
+      for (const testCaseGroup of fs.readdirSync(testsDir)) {
+        // testCaseGroup = "small"
+        const testCaseGroupDir = path.join(testsDir, testCaseGroup);
+        // testCaseDir is: blst-ts/spec-tests/tests/general/altair/bls/eth_aggregate_pubkeys/small
+
+        for (const testCase of fs.readdirSync(testCaseGroupDir)) {
+          // testCase = "eth_aggregate_pubkeys_empty_list"
+          const testCaseDir = path.join(testCaseGroupDir, testCase);
+          // testCaseDir is:
+          // blst-ts/spec-tests/tests/general/altair/bls/eth_aggregate_pubkeys/small/eth_aggregate_pubkeys_empty_list
+
+          it(testCase, () => {
+            // Ensure there are no unknown files
+            const files = fs.readdirSync(testCaseDir);
+            expect(files).to.deep.equal(["data.yaml"], `Unknown files in ${testCaseDir}`);
+
+            // Examples of parsed YAML
+            // {
+            //   input: [
+            //     '0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121',
+            //     '0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df',
+            //     '0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9'
+            //   ],
+            //   output: '0x9712c3edd73a209c742b8250759db12549b3eaf43b5ca61376d9f30e2747dbcf842d8b2ac0901d2a093713e20284a7670fcf6954e9ab93de991bb9b313e664785a075fc285806fa5224c82bde146561b446ccfc706a64b8579513cfc4ff1d930'
+            // }
+            //
+            // {
+            //   input: ['0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'],
+            //   output: null
+            // }
+            //
+            // {
+            //   input: ...,
+            //   output: false
+            // }
+
+            const testData = jsYaml.load(fs.readFileSync(path.join(testCaseDir, "data.yaml"), "utf8")) as TestData;
+
+            if (process.env.DEBUG) {
+              // eslint-disable-next-line no-console
+              console.log(testData);
+            }
+
+            try {
+              expect(testFn(testData.input)).to.deep.equal(testData.output);
+            } catch (e) {
+              // spec test expect a boolean even for invalid inputs
+              if (!isBlstError(e)) throw e;
+
+              expect(false).to.deep.equal(Boolean(testData.output));
+            }
+          });
+        }
+      }
+    });
+  }
+}
+
+/**
+ * ```
+ * input: List[BLS Signature] -- list of input BLS signatures
+ * output: BLS Signature -- expected output, single BLS signature or empty.
+ * ```
+ */
+// function aggregate(input: string[]): string | null {
+//   const agg = functions.aggregateSignaturesSync(input.map((hex) => Signature.deserialize(fromHex(hex))));
+//   return toHex(agg.serialize());
+// }
+
+/**
+ * ```
+ * input:
+ *   pubkeys: List[BLS Pubkey] -- the pubkeys
+ *   messages: List[bytes32] -- the messages
+ *   signature: BLS Signature -- the signature to verify against pubkeys and messages
+ * output: bool  --  true (VALID) or false (INVALID)
+ * ```
+ */
+// function aggregate_verify(input: {pubkeys: string[]; messages: string[]; signature: string}): boolean {
+//   const {pubkeys, messages, signature} = input;
+//   return functions.aggregateVerifySync(
+//     messages.map(fromHex),
+//     pubkeys.map((hex) => PublicKey.deserialize(fromHex(hex))),
+//     Signature.deserialize(fromHex(signature))
+//   );
+// }
+
+/**
+ * ```
+ * input: List[BLS Signature] -- list of input BLS signatures
+ * output: BLS Signature -- expected output, single BLS signature or empty.
+ * ```
+ */
+function eth_aggregate_pubkeys(input: string[]): string | null {
+  // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
+  // for (const pk of input) {
+  //   if (pk === G1_POINT_AT_INFINITY) return null;
+  // }
+
+  const agg = aggregatePublicKeysSync(input.map((hex) => fromHex(hex)));
+  if (agg == null) return null;
+  return normalizeHex(agg.serialize());
+}
+
+/**
+ * ```
+ * input:
+ *   pubkeys: List[BLS Pubkey] -- list of input BLS pubkeys
+ *   message: bytes32 -- the message
+ *   signature: BLS Signature -- the signature to verify against pubkeys and message
+ * output: bool  --  true (VALID) or false (INVALID)
+ * ```
+ */
+// function eth_fast_aggregate_verify(input: {pubkeys: string[]; message: string; signature: string}): boolean {
+//   const {pubkeys, message, signature} = input;
+
+//   if (pubkeys.length === 0 && signature === G2_POINT_AT_INFINITY) {
+//     return true;
+//   }
+
+//   // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
+//   for (const pk of pubkeys) {
+//     if (pk === G1_POINT_AT_INFINITY) return false;
+//   }
+
+//   return functions.fastAggregateVerifySync(
+//     fromHex(message),
+//     pubkeys.map((hex) => PublicKey.deserialize(fromHex(hex))),
+//     Signature.deserialize(fromHex(signature))
+//   );
+// }
+
+/**
+ * ```
+ * input:
+ *   pubkeys: List[BLS Pubkey] -- list of input BLS pubkeys
+ *   message: bytes32 -- the message
+ *   signature: BLS Signature -- the signature to verify against pubkeys and message
+ * output: bool  --  true (VALID) or false (INVALID)
+ * ```
+ */
+// function fast_aggregate_verify(input: {pubkeys: string[]; message: string; signature: string}): boolean | null {
+//   const {pubkeys, message, signature} = input;
+
+//   // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
+//   for (const pk of pubkeys) {
+//     if (pk === G1_POINT_AT_INFINITY) return false;
+//   }
+
+//   return functions.fastAggregateVerifySync(
+//     fromHex(message),
+//     pubkeys.map((hex) => PublicKey.deserialize(fromHex(hex))),
+//     Signature.deserialize(fromHex(signature))
+//   );
+// }
+
+/**
+ * input:
+ *   privkey: bytes32 -- the private key used for signing
+ *   message: bytes32 -- input message to sign (a hash)
+ * output: BLS Signature -- expected output, single BLS signature or empty.
+ */
+// function sign(input: {privkey: string; message: string}): string | null {
+//   const {privkey, message} = input;
+//   const sk = SecretKey.deserialize(fromHex(privkey));
+//   const signature = sk.signSync(fromHex(message));
+//   return toHex(signature.serialize());
+// }
+
+/**
+ * input:
+ *   pubkey: bytes48 -- the pubkey
+ *   message: bytes32 -- the message
+ *   signature: bytes96 -- the signature to verify against pubkey and message
+ * output: bool  -- VALID or INVALID
+ */
+// function verify(input: {pubkey: string; message: string; signature: string}): boolean {
+//   const {pubkey, message, signature} = input;
+//   return functions.verifySync(
+//     fromHex(message),
+//     PublicKey.deserialize(fromHex(pubkey)),
+//     Signature.deserialize(fromHex(signature))
+//   );
+// }
+
+function isBlstError(e: unknown): boolean {
+  return (e as Error).message.includes("BLST_ERROR");
+}

--- a/rebuild/test/spec/specTestVersioning.ts
+++ b/rebuild/test/spec/specTestVersioning.ts
@@ -1,0 +1,14 @@
+import path from "path";
+
+// WARNING! Don't move or rename this file !!!
+//
+// This file is used to generate the cache ID for spec tests download in Github Actions CI
+// It's path is hardcoded in: `.github/workflows/test-spec.yml`
+//
+// The contents of this file MUST include the URL, version and target path, and nothing else.
+
+export const SPEC_TEST_REPO_URL = "https://github.com/ethereum/consensus-spec-tests";
+export const SPEC_TEST_VERSION = "v1.2.0";
+export const SPEC_TEST_TO_DOWNLOAD = ["general"] as const;
+// Target directory is the host package root: '<roo>/spec-tests'
+export const SPEC_TEST_LOCATION = path.join(__dirname, "../../spec-tests");

--- a/rebuild/test/unit/aggregatePublicKeys.test.ts
+++ b/rebuild/test/unit/aggregatePublicKeys.test.ts
@@ -13,11 +13,11 @@ describe("Aggregate Public Keys", () => {
     });
     it("should be able to keyValidate PublicKey", () => {
       const agg = aggregatePublicKeysSync(keys);
-      expect(agg.keyValidateSync()).to.be.undefined;
+      expect(agg!.keyValidateSync()).to.be.undefined;
     });
     it("should return a key that is not in the keys array", () => {
       const agg = aggregatePublicKeysSync(keys);
-      const serialized = agg.serialize();
+      const serialized = agg!.serialize();
       expect(keys.find((key) => key.serialize() == serialized)).to.be.undefined;
     });
   });
@@ -30,12 +30,12 @@ describe("Aggregate Public Keys", () => {
     });
     it("should be able to keyValidate PublicKey", async () => {
       const agg = await aggregatePublicKeys(keys);
-      const res = await agg.keyValidate();
+      const res = await agg!.keyValidate();
       expect(res).to.be.undefined;
     });
     it("should return a key that is not in the keys array", async () => {
       const agg = await aggregatePublicKeys(keys);
-      const serialized = agg.serialize();
+      const serialized = agg!.serialize();
       expect(keys.find((key) => key.serialize() == serialized)).to.be.undefined;
     });
   });

--- a/rebuild/test/unit/aggregateSignatures.test.ts
+++ b/rebuild/test/unit/aggregateSignatures.test.ts
@@ -13,11 +13,11 @@ describe("Aggregate Signatures", () => {
     });
     it("should be able to keyValidate Signature", () => {
       const agg = aggregateSignaturesSync(signatures);
-      expect(agg.sigValidateSync()).to.be.undefined;
+      expect(agg!.sigValidateSync()).to.be.undefined;
     });
     it("should return a key that is not in the keys array", () => {
       const agg = aggregateSignaturesSync(signatures);
-      const serialized = agg.serialize();
+      const serialized = agg!.serialize();
       expect(signatures.find((key) => key.serialize() == serialized)).to.be.undefined;
     });
   });
@@ -30,12 +30,12 @@ describe("Aggregate Signatures", () => {
     });
     it("should be able to keyValidate Signature", async () => {
       const agg = await aggregateSignatures(signatures);
-      const res = await agg.sigValidate();
+      const res = await agg!.sigValidate();
       expect(res).to.be.undefined;
     });
     it("should return a key that is not in the keys array", async () => {
       const agg = await aggregateSignatures(signatures);
-      const serialized = agg.serialize();
+      const serialized = agg!.serialize();
       expect(signatures.find((key) => key.serialize() == serialized)).to.be.undefined;
     });
   });

--- a/rebuild/yarn.lock
+++ b/rebuild/yarn.lock
@@ -1711,6 +1711,11 @@ minipass@^4.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
   integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
 
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
@@ -1785,6 +1790,13 @@ node-addon-api@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
   integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
+
+node-fetch@2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@^9.3.1:
   version "9.3.1"
@@ -2249,6 +2261,18 @@ tar@^6.1.11, tar@^6.1.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+tar@^6.1.14:
+  version "6.1.14"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.14.tgz#e87926bec1cfe7c9e783a77a79f3e81c1cfa3b66"
+  integrity sha512-piERznXu0U7/pW7cdSn7hjqySIVTYT6F76icmFk7ptU7dDYlXTm5r9A6K04R2vU3olYgoKeo1Cg3eeu5nhftAw==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2260,6 +2284,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-node@^10.9.1:
   version "10.9.1"
@@ -2373,6 +2402,19 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR is related to #88 and covers the spec testing for `aggregatePublicKeys` and `aggregateSignatures`

**note**: spec `eth_aggregate_pubkeys_x40_pubkey` fails.  This test is fixed in a subsequent PR

## Inclusions

- spec test `aggregatePublicKeys`
- spec test `aggregateSignatures`

## How to test

**NOTE:** to build and test copy the `blst` folder into `rebuild/deps/blst`.  This will go away when we merge but for now `node-gyp` gets heartburn when building deps in folder above the `binding.gyp` file

```sh
cd rebuild
yarn
yarn download-spec-tests
yarn test:spec
```