### PR TITLE
feat(rebuild): verify functions

### DIFF
--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -115,3 +115,5 @@ export class Signature implements Serializable {
 
 export function verifyMultipleAggregateSignatures(signatureSets: SignatureSet[]): Promise<boolean>;
 export function verifyMultipleAggregateSignaturesSync(signatureSets: SignatureSet[]): boolean;
+export function verify(msg: BlstBuffer, publicKey: PublicKeyArg, signature: SignatureArg): Promise<boolean>;
+export function verifySync(msg: BlstBuffer, publicKey: PublicKeyArg, signature: SignatureArg): boolean;

--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -117,3 +117,15 @@ export function verifyMultipleAggregateSignatures(signatureSets: SignatureSet[])
 export function verifyMultipleAggregateSignaturesSync(signatureSets: SignatureSet[]): boolean;
 export function verify(msg: BlstBuffer, publicKey: PublicKeyArg, signature: SignatureArg): Promise<boolean>;
 export function verifySync(msg: BlstBuffer, publicKey: PublicKeyArg, signature: SignatureArg): boolean;
+export function fastAggregateVerify(
+  msg: BlstBuffer[],
+  publicKey: PublicKeyArg,
+  signature: SignatureArg
+): Promise<boolean>;
+export function fastAggregateVerifySync(msg: BlstBuffer[], publicKey: PublicKeyArg, signature: SignatureArg): boolean;
+export function aggregateVerify(
+  msg: BlstBuffer[],
+  publicKey: PublicKeyArg[],
+  signature: SignatureArg
+): Promise<boolean>;
+export function aggregateVerifySync(msg: BlstBuffer[], publicKey: PublicKeyArg[], signature: SignatureArg): boolean;

--- a/rebuild/lib/index.js
+++ b/rebuild/lib/index.js
@@ -1,2 +1,23 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-call
-module.exports = exports = require("bindings")("blst_ts_addon");
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+const bindings = require("bindings")("blst_ts_addon");
+
+bindings.verify = async function verify(msg, pk, sig) {
+  return bindings.aggregateVerify([msg], [pk], sig);
+};
+bindings.verifySync = function verifySync(msg, pk, sig) {
+  return bindings.aggregateVerifySync([msg], [pk], sig);
+};
+bindings.fastAggregateVerify = async function fastAggregateVerify(msg, pks, sig) {
+  const aggPk = await bindings.aggregatePublicKeys(pks);
+  return bindings.aggregateVerify([msg], [aggPk], sig);
+};
+bindings.fastAggregateVerifySync = function fastAggregateVerifySync(msg, pks, sig) {
+  const aggPk = bindings.aggregatePublicKeysSync(pks);
+  return bindings.aggregateVerifySync([msg], [aggPk], sig);
+};
+
+module.exports = exports = bindings;

--- a/rebuild/package.json
+++ b/rebuild/package.json
@@ -19,7 +19,9 @@
     "build:debug": "node-gyp build --debug",
     "lint": "eslint --color --ext .ts lib/ test/",
     "test": "yarn test:unit",
-    "test:unit": "mocha test/unit/**/*.test.ts"
+    "test:unit": "mocha test/unit/**/*.test.ts",
+    "test:spec": "mocha 'test/spec/**/*.test.ts'",
+    "download-spec-tests": "node -r ts-node/register test/spec/downloadTests.ts"
   },
   "repository": {
     "type": "git",

--- a/rebuild/test/__fixtures__/index.ts
+++ b/rebuild/test/__fixtures__/index.ts
@@ -1,4 +1,4 @@
-import {fromHex, getFilledUint8, makeNapiTestSet, makeNapiTestSets} from "../utils";
+import {fromHex, getFilledUint8, makeNapiTestSet, makeNapiTestSets, sullyUint8Array} from "../utils";
 
 export const invalidInputs: [string, any][] = [
   ["numbers", 2],
@@ -42,12 +42,8 @@ export const validSignature = {
     "a57565542eaa01ef2b910bf0eaba4d98a1e5b8b79cc425db08f8780732d0ea9bc85fc6175f272b2344bb27bc572ebf14022e52689dcedfccf44a00e5bd1aa59db44517217d6b0f21b372169ee761938c28914ddcb9663de54db288e760a8e14f"
   ),
 };
-export const badSignature = Uint8Array.from(
-  Buffer.from([
-    ...Uint8Array.prototype.slice.call(makeNapiTestSet().signature.serialize(false), 8),
-    ...Buffer.from("0123456789abcdef", "hex"),
-  ])
-);
+
+export const badSignature = sullyUint8Array(makeNapiTestSet().signature.serialize(false));
 
 export const validSignatureSet = makeNapiTestSets(1).map((set) => {
   const {msg, secretKey, publicKey, signature} = set;

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import jsYaml from "js-yaml";
 import {SPEC_TEST_LOCATION} from "./specTestVersioning";
-import {PublicKey, aggregatePublicKeysSync, aggregateSignaturesSync} from "../../lib";
+import {PublicKey, Signature, verifySync} from "../../lib";
 import {fromHex, normalizeHex} from "../utils";
 
 interface TestData {
@@ -21,13 +21,13 @@ interface TestData {
 
 const generalTestsDir = path.join(SPEC_TEST_LOCATION, "tests/general");
 const blsTestToFunctionMap: Record<string, (data: any) => any> = {
-  aggregate,
+  // aggregate,
   // aggregate_verify,
-  eth_aggregate_pubkeys,
+  // eth_aggregate_pubkeys,
   // eth_fast_aggregate_verify,
   // fast_aggregate_verify,
   // sign,
-  // verify,
+  verify,
 };
 
 for (const forkName of fs.readdirSync(generalTestsDir)) {
@@ -112,11 +112,11 @@ for (const forkName of fs.readdirSync(generalTestsDir)) {
  * output: BLS Signature -- expected output, single BLS signature or empty.
  * ```
  */
-function aggregate(input: string[]): string | null {
-  const agg = aggregateSignaturesSync(input.map((hex) => fromHex(hex)));
-  if (agg === null) return agg;
-  return normalizeHex(agg.serialize());
-}
+// function aggregate(input: string[]): string | null {
+//   const agg = aggregateSignaturesSync(input.map((hex) => fromHex(hex)));
+//   if (agg === null) return agg;
+//   return normalizeHex(agg.serialize());
+// }
 
 /**
  * ```
@@ -142,11 +142,11 @@ function aggregate(input: string[]): string | null {
  * output: BLS Signature -- expected output, single BLS signature or empty.
  * ```
  */
-function eth_aggregate_pubkeys(input: string[]): string | null {
-  const agg = aggregatePublicKeysSync(input.map((hex) => fromHex(hex)));
-  if (agg == null) return agg;
-  return normalizeHex(agg.serialize());
-}
+// function eth_aggregate_pubkeys(input: string[]): string | null {
+//   const agg = aggregatePublicKeysSync(input.map((hex) => fromHex(hex)));
+//   if (agg == null) return agg;
+//   return normalizeHex(agg.serialize());
+// }
 
 /**
  * ```
@@ -220,14 +220,10 @@ function eth_aggregate_pubkeys(input: string[]): string | null {
  *   signature: bytes96 -- the signature to verify against pubkey and message
  * output: bool  -- VALID or INVALID
  */
-// function verify(input: {pubkey: string; message: string; signature: string}): boolean {
-//   const {pubkey, message, signature} = input;
-//   return functions.verifySync(
-//     fromHex(message),
-//     PublicKey.deserialize(fromHex(pubkey)),
-//     Signature.deserialize(fromHex(signature))
-//   );
-// }
+function verify(input: {pubkey: string; message: string; signature: string}): boolean {
+  const {pubkey, message, signature} = input;
+  return verifySync(fromHex(message), fromHex(pubkey), fromHex(signature));
+}
 
 function isBlstError(e: unknown): boolean {
   return (e as Error).message.includes("BLST_ERROR");

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import path from "path";
 import jsYaml from "js-yaml";
 import {SPEC_TEST_LOCATION} from "./specTestVersioning";
-import {PublicKey, Signature, verifySync} from "../../lib";
+import {PublicKey, Signature, aggregateVerifySync, verifySync} from "../../lib";
 import {fromHex, normalizeHex} from "../utils";
 
 interface TestData {
@@ -22,7 +22,7 @@ interface TestData {
 const generalTestsDir = path.join(SPEC_TEST_LOCATION, "tests/general");
 const blsTestToFunctionMap: Record<string, (data: any) => any> = {
   // aggregate,
-  // aggregate_verify,
+  aggregate_verify,
   // eth_aggregate_pubkeys,
   // eth_fast_aggregate_verify,
   // fast_aggregate_verify,
@@ -127,14 +127,14 @@ for (const forkName of fs.readdirSync(generalTestsDir)) {
  * output: bool  --  true (VALID) or false (INVALID)
  * ```
  */
-// function aggregate_verify(input: {pubkeys: string[]; messages: string[]; signature: string}): boolean {
-//   const {pubkeys, messages, signature} = input;
-//   return functions.aggregateVerifySync(
-//     messages.map(fromHex),
-//     pubkeys.map((hex) => PublicKey.deserialize(fromHex(hex))),
-//     Signature.deserialize(fromHex(signature))
-//   );
-// }
+function aggregate_verify(input: {pubkeys: string[]; messages: string[]; signature: string}): boolean {
+  const {pubkeys, messages, signature} = input;
+  return aggregateVerifySync(
+    messages.map(fromHex),
+    pubkeys.map((hex) => fromHex(hex)),
+    fromHex(signature)
+  );
+}
 
 /**
  * ```

--- a/rebuild/test/unit/verify.test.ts
+++ b/rebuild/test/unit/verify.test.ts
@@ -1,5 +1,12 @@
 import {expect} from "chai";
-import {verify, verifySync} from "../../lib";
+import {
+  aggregateVerify,
+  aggregateVerifySync,
+  fastAggregateVerify,
+  fastAggregateVerifySync,
+  verify,
+  verifySync,
+} from "../../lib";
 import {sullyUint8Array, makeNapiTestSets} from "../utils";
 import {NapiTestSet} from "../types";
 
@@ -35,6 +42,89 @@ describe("Verify", () => {
     });
     it("should return true for valid sets", async () => {
       expect(await verify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+    });
+  });
+});
+
+describe("Aggregate Verify", () => {
+  let testSet: NapiTestSet;
+  before(() => {
+    testSet = makeNapiTestSets(1)[0];
+  });
+  describe("aggregateVerifySync", () => {
+    it("should return a boolean", () => {
+      expect(aggregateVerifySync([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.a("boolean");
+    });
+    it("should default to false", () => {
+      expect(aggregateVerifySync([sullyUint8Array(testSet.msg)], [testSet.publicKey], testSet.signature)).to.be.false;
+      expect(aggregateVerifySync([testSet.msg], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
+        .be.false;
+      expect(aggregateVerifySync([testSet.msg], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
+        .be.false;
+    });
+    it("should return true for valid sets", () => {
+      expect(aggregateVerifySync([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.true;
+    });
+  });
+  describe("aggregateVerify", () => {
+    it("should return Promise<boolean>", async () => {
+      const resPromise = aggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature);
+      expect(resPromise).to.be.instanceOf(Promise);
+      const res = await resPromise;
+      expect(res).to.be.a("boolean");
+    });
+    it("should default to Promise<false>", async () => {
+      expect(await aggregateVerify([sullyUint8Array(testSet.msg)], [testSet.publicKey], testSet.signature)).to.be.false;
+      expect(await aggregateVerify([testSet.msg], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature))
+        .to.be.false;
+      expect(await aggregateVerify([testSet.msg], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize())))
+        .to.be.false;
+    });
+    it("should return true for valid sets", async () => {
+      expect(await aggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.true;
+    });
+  });
+});
+
+describe.skip("Fast Aggregate Verify", () => {
+  let testSet: NapiTestSet;
+  before(() => {
+    testSet = makeNapiTestSets(1)[0];
+  });
+  describe("fastAggregateVerifySync", () => {
+    it("should return a boolean", () => {
+      expect(fastAggregateVerifySync([testSet.msg], testSet.publicKey, testSet.signature)).to.be.a("boolean");
+    });
+    it("should default to false", () => {
+      expect(fastAggregateVerifySync([sullyUint8Array(testSet.msg)], testSet.publicKey, testSet.signature)).to.be.false;
+      expect(fastAggregateVerifySync([testSet.msg], sullyUint8Array(testSet.publicKey.serialize()), testSet.signature))
+        .to.be.false;
+      expect(fastAggregateVerifySync([testSet.msg], testSet.publicKey, sullyUint8Array(testSet.signature.serialize())))
+        .to.be.false;
+    });
+    it("should return true for valid sets", () => {
+      expect(fastAggregateVerifySync([testSet.msg], testSet.publicKey, testSet.signature)).to.be.true;
+    });
+  });
+  describe("fastAggregateVerify", () => {
+    it("should return Promise<boolean>", async () => {
+      const resPromise = fastAggregateVerify([testSet.msg], testSet.publicKey, testSet.signature);
+      expect(resPromise).to.be.instanceOf(Promise);
+      const res = await resPromise;
+      expect(res).to.be.a("boolean");
+    });
+    it("should default to Promise<false>", async () => {
+      expect(await fastAggregateVerify([sullyUint8Array(testSet.msg)], testSet.publicKey, testSet.signature)).to.be
+        .false;
+      expect(
+        await fastAggregateVerify([testSet.msg], sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)
+      ).to.be.false;
+      expect(
+        await fastAggregateVerify([testSet.msg], testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))
+      ).to.be.false;
+    });
+    it("should return true for valid sets", async () => {
+      expect(await fastAggregateVerify([testSet.msg], testSet.publicKey, testSet.signature)).to.be.true;
     });
   });
 });

--- a/rebuild/test/unit/verify.test.ts
+++ b/rebuild/test/unit/verify.test.ts
@@ -1,0 +1,40 @@
+import {expect} from "chai";
+import {verify, verifySync} from "../../lib";
+import {sullyUint8Array, makeNapiTestSets} from "../utils";
+import {NapiTestSet} from "../types";
+
+describe("Verify", () => {
+  let testSet: NapiTestSet;
+  before(() => {
+    testSet = makeNapiTestSets(1)[0];
+  });
+  describe("verifySync", () => {
+    it("should return a boolean", () => {
+      expect(verifySync(testSet.msg, testSet.publicKey, testSet.signature)).to.be.a("boolean");
+    });
+    it("should default to false", () => {
+      expect(verifySync(sullyUint8Array(testSet.msg), testSet.publicKey, testSet.signature)).to.be.false;
+      expect(verifySync(testSet.msg, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be.false;
+      expect(verifySync(testSet.msg, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be.false;
+    });
+    it("should return true for valid sets", () => {
+      expect(verifySync(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+    });
+  });
+  describe("verify", () => {
+    it("should return Promise<boolean>", async () => {
+      const resPromise = verify(testSet.msg, testSet.publicKey, testSet.signature);
+      expect(resPromise).to.be.instanceOf(Promise);
+      const res = await resPromise;
+      expect(res).to.be.a("boolean");
+    });
+    it("should default to Promise<false>", async () => {
+      expect(await verify(sullyUint8Array(testSet.msg), testSet.publicKey, testSet.signature)).to.be.false;
+      expect(await verify(testSet.msg, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be.false;
+      expect(await verify(testSet.msg, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be.false;
+    });
+    it("should return true for valid sets", async () => {
+      expect(await verify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+    });
+  });
+});

--- a/rebuild/test/utils.ts
+++ b/rebuild/test/utils.ts
@@ -37,6 +37,12 @@ export function getFilledUint8(length: number, fillWith: string | number | Buffe
   return Uint8Array.from(Buffer.alloc(length, fillWith));
 }
 
+export function sullyUint8Array(bytes: Uint8Array): Uint8Array {
+  return Uint8Array.from(
+    Buffer.from([...Uint8Array.prototype.slice.call(bytes, 8), ...Buffer.from("0123456789abcdef", "hex")])
+  );
+}
+
 const DEFAULT_TEST_MESSAGE = Uint8Array.from(Buffer.from("test-message"));
 
 export function makeNapiTestSet(msg: Uint8Array = DEFAULT_TEST_MESSAGE): NapiTestSet {


### PR DESCRIPTION
This PR is related to #88 and covers`verify` and `aggregateVerify`

## Inclusions

- `verify`
- `verifySync`
- `aggregateVerify`
- `aggregateVerifySync`
- Unit tests
- Spec tests

## How to test

**NOTE:** to build and test copy the `blst` folder into `rebuild/deps/blst`.  This will go away when we merge but for now `node-gyp` gets heartburn when building deps in folder above the `binding.gyp` file

Unit tests are provided and *should* have 100% coverage.  If you see an edge that may not be covered please feel free to bring it up and I will add the test case

```sh
cd rebuild
yarn
yarn build
yarn test:unit
yarn test:spec
```