### PR TITLE
bug(fastAggregateVerify): issue rectifying specs for altair and phase0

### DIFF
--- a/rebuild/lib/index.js
+++ b/rebuild/lib/index.js
@@ -12,12 +12,22 @@ bindings.verifySync = function verifySync(msg, pk, sig) {
   return bindings.aggregateVerifySync([msg], [pk], sig);
 };
 bindings.fastAggregateVerify = async function fastAggregateVerify(msg, pks, sig) {
-  const aggPk = await bindings.aggregatePublicKeys(pks);
-  return bindings.aggregateVerify([msg], [aggPk], sig);
+  try {
+    const aggPk = await bindings.aggregatePublicKeys(pks);
+    return bindings.aggregateVerify([msg], [aggPk], sig);
+  } catch {
+    return false;
+  }
 };
 bindings.fastAggregateVerifySync = function fastAggregateVerifySync(msg, pks, sig) {
-  const aggPk = bindings.aggregatePublicKeysSync(pks);
-  return bindings.aggregateVerifySync([msg], [aggPk], sig);
+  try {
+    const keys = [];
+    const aggPk = bindings.aggregatePublicKeysSync(pks);
+    if (aggPk !== null) keys.push(aggPk);
+    return bindings.aggregateVerifySync([msg], keys, sig);
+  } catch {
+    return false;
+  }
 };
 
 module.exports = exports = bindings;

--- a/rebuild/src/functions.cc
+++ b/rebuild/src/functions.cc
@@ -16,6 +16,7 @@ namespace
             : BlstAsyncWorker(info),
               _invalid_args{false},
               _no_keys{false},
+              _no_msgs{false},
               _result{false},
               _ctx{new blst::Pairing{true, _module->_dst}},
               _msgs{_env, _info[0], "msg", "msgs"},
@@ -57,12 +58,9 @@ namespace
 
         void Execute() override
         {
-            if (_no_keys && _signature._signature->AsJacobian()->is_inf())
-            {
-                _result = !_no_msgs;
-                return;
-            }
-            if (_invalid_args)
+            if (_invalid_args ||
+                (_no_keys &&
+                 _signature._signature->AsJacobian()->is_inf()))
             {
                 _result = false;
                 return;

--- a/rebuild/src/signature.h
+++ b/rebuild/src/signature.h
@@ -28,6 +28,8 @@ public:
 class SignatureArg : public BlstBase
 {
 public:
+    Signature *_signature;
+    
     SignatureArg(Napi::Env env);
     SignatureArg(Napi::Env env, Napi::Value raw_arg);
     SignatureArg(const SignatureArg &source) = delete;
@@ -40,7 +42,6 @@ public:
     const blst::P2_Affine *AsAffine();
 
 private:
-    Signature *_signature;
     Uint8ArrayArg _bytes;
     Napi::Reference<Napi::Value> _ref;
 };

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -27,13 +27,13 @@ interface TestData {
 
 const generalTestsDir = path.join(SPEC_TEST_LOCATION, "tests/general");
 const blsTestToFunctionMap: Record<string, (data: any) => any> = {
-  aggregate,
-  aggregate_verify,
-  eth_aggregate_pubkeys,
+  // aggregate,
+  // aggregate_verify,
+  // eth_aggregate_pubkeys,
   eth_fast_aggregate_verify,
   fast_aggregate_verify,
   // sign,
-  verify,
+  // verify,
 };
 
 for (const forkName of fs.readdirSync(generalTestsDir)) {

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -20,20 +20,20 @@ interface TestData {
 // Example full path
 // blst-ts/spec-tests/tests/general/altair/bls/eth_aggregate_pubkeys/small/eth_aggregate_pubkeys_empty_list
 
-// const G2_POINT_AT_INFINITY =
-//   "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const G2_POINT_AT_INFINITY =
+  "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 // const G1_POINT_AT_INFINITY =
 //   "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 const generalTestsDir = path.join(SPEC_TEST_LOCATION, "tests/general");
 const blsTestToFunctionMap: Record<string, (data: any) => any> = {
-  // aggregate,
-  // aggregate_verify,
-  // eth_aggregate_pubkeys,
+  aggregate,
+  aggregate_verify,
+  eth_aggregate_pubkeys,
   eth_fast_aggregate_verify,
   fast_aggregate_verify,
   // sign,
-  // verify,
+  verify,
 };
 
 for (const forkName of fs.readdirSync(generalTestsDir)) {
@@ -166,9 +166,9 @@ function eth_aggregate_pubkeys(input: string[]): string | null {
 function eth_fast_aggregate_verify(input: {pubkeys: string[]; message: string; signature: string}): boolean {
   const {pubkeys, message, signature} = input;
 
-  // if (pubkeys.length === 0 && signature === G2_POINT_AT_INFINITY) {
-  //   return true;
-  // }
+  if (pubkeys.length === 0 && signature === G2_POINT_AT_INFINITY) {
+    return true;
+  }
 
   // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
   // for (const pk of pubkeys) {


### PR DESCRIPTION
This PR is related to #88 and covers spec testing of `fatsAggregateVerify`

_**note:** I was unable to rectify `phase0/fast_aggregate_verify_na_pubkeys_and_infinity_signature` and `altair/eth_fast_aggregate_verify_na_pubkeys_and_infinity_signature` with c.  The spec tests for identical conditions that changed between forks.  Without programmatic knowledge of the fork its not possible to return both true and false for the same conditions.  I used the method in the existing spec tests of checking in the wrapper function that converts the spec name to the correct function [here](https://github.com/ChainSafe/blst-ts/blob/b56ff0a90eb2b9a3d86d912b544e2c336f75baf3/rebuild/test/spec/index.test.ts#L169)_

## Inclusions

- Spec tests and required code changes for `fastAggregateVerify`

## How to test

**NOTE:** to build and test copy the `blst` folder into `rebuild/deps/blst`.  This will go away when we merge but for now `node-gyp` gets heartburn when building deps in folder above the `binding.gyp` file

Unit tests are provided and *should* have 100% coverage.  If you see an edge that may not be covered please feel free to bring it up and I will add the test case

```sh
cd rebuild
yarn
yarn build
yarn test:unit
yarn test:spec
```