### PR TITLE
test(spec): SecretKey.sign

### DIFF
--- a/rebuild/src/addon.cc
+++ b/rebuild/src/addon.cc
@@ -3,6 +3,24 @@
 /**
  *
  *
+ * BlstBase
+ *
+ *
+ */
+bool BlstBase::IsZeroBytes(const uint8_t *data, size_t start_byte, size_t byte_length)
+{
+    for (size_t i = start_byte; i < byte_length; i++)
+    {
+        if (data[i] != 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+/**
+ *
+ *
  * BlstAsyncWorker
  *
  *
@@ -156,17 +174,6 @@ bool Uint8ArrayArg::ValidateLength(size_t length1, size_t length2)
     }
     return is_valid;
 };
-bool Uint8ArrayArg::IsZeroBytes()
-{
-    for (size_t i = 0; i < ByteLength(); i++)
-    {
-        if (_data[i] != 0)
-        {
-            return false;
-        }
-    }
-    return true;
-}
 /**
  *
  *

--- a/rebuild/src/addon.h
+++ b/rebuild/src/addon.h
@@ -68,6 +68,7 @@ typedef enum
 class BlstBase
 {
 public:
+    bool IsZeroBytes(const uint8_t *data, size_t start_byte, size_t byte_length);
     bool HasError() { return _error.size() > 0; };
     std::string GetError() { return _error; };
     void ThrowJsException()
@@ -203,7 +204,6 @@ public:
     const uint8_t *Data();
     size_t ByteLength();
     bool ValidateLength(size_t length1, size_t length2 = 0);
-    bool IsZeroBytes();
 
 protected:
     std::string _error_prefix;

--- a/rebuild/src/public_key.cc
+++ b/rebuild/src/public_key.cc
@@ -293,7 +293,7 @@ PublicKeyArg::PublicKeyArg(Napi::Env env, Napi::Value raw_arg)
         wrapped.TypeTag(&_module->_public_key_tag);
         _ref = Napi::Persistent(wrapped);
         _public_key = PublicKey::Unwrap(wrapped);
-        if (_bytes.IsZeroBytes())
+        if (_bytes.IsZeroBytes(_bytes.Data(), 0, _bytes.ByteLength()))
         {
             _public_key->_jacobian.reset(new blst::P1{});
             _public_key->_is_zero_key = true;

--- a/rebuild/src/secret_key.h
+++ b/rebuild/src/secret_key.h
@@ -12,6 +12,7 @@ class SecretKey : public Napi::ObjectWrap<SecretKey>
 {
 public:
     std::unique_ptr<blst::SecretKey> _key;
+    bool _is_zero_key;
 
     static void Init(Napi::Env env, Napi::Object &exports, BlstTsAddon *module);
     static Napi::Value FromKeygen(const Napi::CallbackInfo &info);

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -4,6 +4,7 @@ import path from "path";
 import jsYaml from "js-yaml";
 import {SPEC_TEST_LOCATION} from "./specTestVersioning";
 import {
+  SecretKey,
   aggregatePublicKeysSync,
   aggregateSignaturesSync,
   aggregateVerifySync,
@@ -32,7 +33,7 @@ const blsTestToFunctionMap: Record<string, (data: any) => any> = {
   eth_aggregate_pubkeys,
   eth_fast_aggregate_verify,
   fast_aggregate_verify,
-  // sign,
+  sign,
   verify,
 };
 
@@ -212,12 +213,13 @@ function fast_aggregate_verify(input: {pubkeys: string[]; message: string; signa
  *   message: bytes32 -- input message to sign (a hash)
  * output: BLS Signature -- expected output, single BLS signature or empty.
  */
-// function sign(input: {privkey: string; message: string}): string | null {
-//   const {privkey, message} = input;
-//   const sk = SecretKey.deserialize(fromHex(privkey));
-//   const signature = sk.signSync(fromHex(message));
-//   return toHex(signature.serialize());
-// }
+function sign(input: {privkey: string; message: string}): string | null {
+  const {privkey, message} = input;
+  const sk = SecretKey.deserialize(fromHex(privkey));
+  const signature = sk.signSync(fromHex(message));
+  if (signature === null) return signature;
+  return normalizeHex(signature.serialize());
+}
 
 /**
  * input:


### PR DESCRIPTION
This PR is related to #88 and covers spec testing of the `sign` method on `SecretKey` instances.

## Inclusions
- Spec test for `sign`

## How to test

**NOTE:** to build and test copy the `blst` folder into `rebuild/deps/blst`.  This will go away when we merge but for now `node-gyp` gets heartburn when building deps in folder above the `binding.gyp` file

Unit tests are provided and *should* have 100% coverage.  If you see an edge that may not be covered please feel free to bring it up and I will add the test case

```sh
cd rebuild
yarn
yarn build
yarn test:spec
```