### PR TITLE
test(rebuild): add spec tests

### DIFF
--- a/rebuild/.eslintrc.cjs
+++ b/rebuild/.eslintrc.cjs
@@ -11,8 +11,12 @@ module.exports = {
   },
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    ecmaVersion: 10,
+    ecmaVersion: 12,
     project: "./tsconfig.json",
+    sourceType: "module",
+    ecmaFeatures:{
+      modules: true
+    }
   },
   plugins: ["@typescript-eslint", "eslint-plugin-import", "eslint-plugin-node", "prettier"],
   extends: [
@@ -51,6 +55,7 @@ module.exports = {
     "@typescript-eslint/explicit-member-accessibility": ["error", {accessibility: "no-public"}],
     "@typescript-eslint/no-unsafe-call": "error",
     "@typescript-eslint/no-unsafe-return": "error",
+    "import/no-unresolved": "off",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -79,6 +84,12 @@ module.exports = {
   },
   settings: {
     "import/core-modules": ["node:child_process", "node:crypto", "node:fs", "node:os", "node:path", "node:util"],
+    'import/resolver': {
+      node: {
+        extensions: [".js", ".ts"],
+        moduleDirectory: ["lib/", "test/", "node_modules/"]
+      }
+    },
   },
   overrides: [
     {

--- a/rebuild/.mocharc.cjs
+++ b/rebuild/.mocharc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  colors: true,
+  require: "ts-node/register",
+  exit: true,
+  loader: "ts-node/esm"
+}

--- a/rebuild/.mocharc.yaml
+++ b/rebuild/.mocharc.yaml
@@ -1,3 +1,0 @@
-colors: true
-require: ts-node/register
-exit: true

--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -16,7 +16,7 @@ export type BlstBuffer = Uint8Array;
 export type PublicKeyArg = BlstBuffer | PublicKey;
 export type SignatureArg = BlstBuffer | Signature;
 export interface SignatureSet {
-  msg: BlstBuffer;
+  message: BlstBuffer;
   publicKey: PublicKeyArg;
   signature: SignatureArg;
 }
@@ -71,6 +71,7 @@ export class SecretKey implements Serializable {
    * Serialize a secret key into a Buffer.
    */
   serialize(): Buffer;
+  toHex(): string;
   toPublicKey(): PublicKey;
   sign(msg: BlstBuffer): Signature;
 }
@@ -79,6 +80,7 @@ export class PublicKey implements Serializable {
   private constructor();
   static deserialize(skBytes: BlstBuffer, coordType?: CoordType): PublicKey;
   serialize(compress?: boolean): Buffer;
+  toHex(compress?: boolean): string;
   keyValidate(): void;
 }
 
@@ -86,6 +88,7 @@ export class Signature implements Serializable {
   private constructor();
   static deserialize(skBytes: BlstBuffer, coordType?: CoordType): Signature;
   serialize(compress?: boolean): Buffer;
+  toHex(compress?: boolean): string;
   sigValidate(): void;
 }
 

--- a/rebuild/lib/index.js
+++ b/rebuild/lib/index.js
@@ -3,41 +3,96 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-const bindings = require("bindings")("blst_ts_addon");
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const {default: getBindings} = await import("bindings");
+const bindings = getBindings("blst_ts_addon");
+const {
+  BLST_CONSTANTS,
+  SecretKey,
+  PublicKey,
+  Signature,
+  aggregatePublicKeys,
+  aggregateSignatures,
+  aggregateVerify,
+  verifyMultipleAggregateSignatures,
+  asyncAggregateVerify,
+  asyncVerifyMultipleAggregateSignatures,
+} = bindings;
 
-bindings.verify = function verify(msg, pk, sig) {
-  return bindings.aggregateVerify([msg], [pk], sig);
+SecretKey.prototype.toHex = function () {
+  return `0x${this.serialize().toString("hex")}`;
 };
 
-bindings.asyncVerify = function asyncVerify(msg, pk, sig) {
-  return bindings.asyncAggregateVerify([msg], [pk], sig);
+PublicKey.prototype.toHex = function (compress) {
+  return `0x${this.serialize(compress).toString("hex")}`;
 };
 
-bindings.fastAggregateVerify = function fastAggregateVerify(msg, pks, sig) {
+Signature.prototype.toHex = function (compress) {
+  return `0x${this.serialize(compress).toString("hex")}`;
+};
+
+export {
+  BLST_CONSTANTS,
+  SecretKey,
+  PublicKey,
+  Signature,
+  aggregatePublicKeys,
+  aggregateSignatures,
+  aggregateVerify,
+  verifyMultipleAggregateSignatures,
+  asyncAggregateVerify,
+  asyncVerifyMultipleAggregateSignatures,
+};
+
+export function verify(msg, pk, sig) {
+  return aggregateVerify([msg], [pk], sig);
+}
+
+export function asyncVerify(msg, pk, sig) {
+  return asyncAggregateVerify([msg], [pk], sig);
+}
+
+export function fastAggregateVerify(msg, pks, sig) {
   let key;
   try {
     // this throws for invalid key, catch and return false
-    key = bindings.aggregatePublicKeys(pks);
+    key = aggregatePublicKeys(pks);
   } catch {
     return false;
   }
-  return bindings.aggregateVerify([msg], [key], sig);
-};
+  return aggregateVerify([msg], [key], sig);
+}
 
-bindings.asyncFastAggregateVerify = function asyncFastAggregateVerify(msg, pks, sig) {
+export function asyncFastAggregateVerify(msg, pks, sig) {
   let key;
   try {
     // this throws for invalid key, catch and return false
-    key = bindings.aggregatePublicKeys(pks);
+    key = aggregatePublicKeys(pks);
   } catch {
     return false;
   }
-  return bindings.asyncAggregateVerify([msg], [key], sig);
-};
+  return asyncAggregateVerify([msg], [key], sig);
+}
 
-bindings.CoordType = {
+export const CoordType = {
   affine: 0,
   jacobian: 1,
 };
 
-module.exports = exports = bindings;
+export default {
+  CoordType,
+  BLST_CONSTANTS,
+  SecretKey,
+  PublicKey,
+  Signature,
+  aggregatePublicKeys,
+  aggregateSignatures,
+  verify,
+  aggregateVerify,
+  fastAggregateVerify,
+  verifyMultipleAggregateSignatures,
+  asyncVerify,
+  asyncAggregateVerify,
+  asyncFastAggregateVerify,
+  asyncVerifyMultipleAggregateSignatures,
+};

--- a/rebuild/package.json
+++ b/rebuild/package.json
@@ -2,8 +2,6 @@
   "name": "@chainsafe/blst-ts",
   "version": "1.0.0",
   "description": "Typescript wrapper for supranational/blst native bindings, a highly performant BLS12-381 signature library",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "gypfile": true,
   "private": false,
   "files": [
@@ -12,6 +10,26 @@
     "lib",
     "src"
   ],
+  "type": "module",
+  "main": "./import/index.js",
+  "module": "./import/index.js",
+  "types": "./import/index.d.ts",
+  "exports": {
+    ".": "./import/index.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./import/index.d.ts"
+      ]
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./import/index.js"
+    },
+    "types": "./import/index.d.ts"
+  },
   "scripts": {
     "preinstall": "mkdir -p deps && cp -r ../blst deps",
     "clean": "npm run clean:dist; npm run clean:build",
@@ -24,7 +42,7 @@
     "lint:ts": "eslint --color --ext .ts lib/ test/",
     "lint:c": "clang-format -i ./src/*",
     "lint": "npm run lint:c && npm run lint:ts",
-    "test": "yarn test:unit",
+    "test": "yarn test:unit && yarn test:spec",
     "test:unit": "mocha test/unit/**/*.test.ts",
     "test:spec": "mocha 'test/spec/**/*.test.ts'",
     "download-spec-tests": "node -r ts-node/register test/spec/downloadTests.ts"

--- a/rebuild/src/addon.cc
+++ b/rebuild/src/addon.cc
@@ -62,7 +62,8 @@ BlstTsAddon::BlstTsAddon(Napi::Env env, Napi::Object exports)
     // Check that openssl PRNG is seeded
     blst::byte seed{0};
     if (!this->GetRandomBytes(&seed, 0)) {
-        Napi::Error::New(env, "BLST_ERROR: Error seeding pseudo-random number generator")
+        Napi::Error::New(
+            env, "BLST_ERROR: Error seeding pseudo-random number generator")
             .ThrowAsJavaScriptException();
     }
 }

--- a/rebuild/src/addon.cc
+++ b/rebuild/src/addon.cc
@@ -62,7 +62,7 @@ BlstTsAddon::BlstTsAddon(Napi::Env env, Napi::Object exports)
     // Check that openssl PRNG is seeded
     blst::byte seed{0};
     if (!this->GetRandomBytes(&seed, 0)) {
-        Napi::Error::New(env, "Error seeding pseudo-random number generator")
+        Napi::Error::New(env, "BLST_ERROR: Error seeding pseudo-random number generator")
             .ThrowAsJavaScriptException();
     }
 }

--- a/rebuild/src/addon.cc
+++ b/rebuild/src/addon.cc
@@ -37,13 +37,13 @@ BlstTsAddon::BlstTsAddon(Napi::Env env, Napi::Object exports)
     : _dst{"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_"},
       _blst_error_strings{
           "BLST_SUCCESS",
-          "BLST_BAD_ENCODING",
-          "BLST_POINT_NOT_ON_CURVE",
-          "BLST_POINT_NOT_IN_GROUP",
-          "BLST_AGGR_TYPE_MISMATCH",
-          "BLST_VERIFY_FAIL",
-          "BLST_PK_IS_INFINITY",
-          "BLST_BAD_SCALAR",
+          "BLST_ERROR::BLST_BAD_ENCODING",
+          "BLST_ERROR::BLST_POINT_NOT_ON_CURVE",
+          "BLST_ERROR::BLST_POINT_NOT_IN_GROUP",
+          "BLST_ERROR::BLST_AGGR_TYPE_MISMATCH",
+          "BLST_ERROR::BLST_VERIFY_FAIL",
+          "BLST_ERROR::BLST_PK_IS_INFINITY",
+          "BLST_ERROR::BLST_BAD_SCALAR",
       } {
     Napi::Object js_constants = Napi::Object::New(env);
     js_constants.Set(

--- a/rebuild/src/addon.h
+++ b/rebuild/src/addon.h
@@ -25,13 +25,15 @@ using std::endl;
 
 #define BLST_TS_UNWRAP_UINT_8_ARRAY(value_name, arr_name, js_name, ret_val)    \
     if (!value_name.IsTypedArray()) {                                          \
-        Napi::TypeError::New(env, js_name " must be a BlstBuffer")             \
+        Napi::TypeError::New(                                                  \
+            env, "BLST_ERROR: " js_name " must be a BlstBuffer")               \
             .ThrowAsJavaScriptException();                                     \
         return ret_val;                                                        \
     }                                                                          \
     Napi::TypedArray arr_name##_array = value_name.As<Napi::TypedArray>();     \
     if (arr_name##_array.TypedArrayType() != napi_uint8_array) {               \
-        Napi::TypeError::New(env, js_name " must be a BlstBuffer")             \
+        Napi::TypeError::New(                                                  \
+            env, "BLST_ERROR: " js_name " must be a BlstBuffer")               \
             .ThrowAsJavaScriptException();                                     \
         return ret_val;                                                        \
     }                                                                          \
@@ -69,7 +71,9 @@ using std::endl;
                    : _affine->serialize(serialized.Data());                    \
     } else {                                                                   \
         Napi::Error::New(                                                      \
-            env, class_name " cannot be serialized. No point found!")          \
+            env,                                                               \
+            "BLST_ERROR: " class_name                                          \
+            " cannot be serialized. No point found!")                          \
             .ThrowAsJavaScriptException();                                     \
         return scope.Escape(env.Undefined());                                  \
     }                                                                          \
@@ -95,12 +99,13 @@ using std::endl;
         Napi::TypedArray untyped = val_name.As<Napi::TypedArray>();            \
         if (untyped.TypedArrayType() != napi_uint8_array) {                    \
             Napi::TypeError::New(                                              \
-                env, pascal_case_string "Arg must be a BlstBuffer")            \
+                env,                                                           \
+                "BLST_ERROR: " pascal_case_string "Arg must be a BlstBuffer")  \
                 .ThrowAsJavaScriptException();                                 \
             has_error = true;                                                  \
         }                                                                      \
         Napi::Uint8Array typed = untyped.As<Napi::Uint8Array>();               \
-        std::string err_out{pascal_case_string "Arg"};                         \
+        std::string err_out{"BLST_ERROR: " pascal_case_string "Arg"};          \
         if (!is_valid_length(                                                  \
                 err_out,                                                       \
                 typed.ByteLength(),                                            \
@@ -111,7 +116,8 @@ using std::endl;
         }                                                                      \
         if (pascal_case_string[0] == 'P' &&                                    \
             is_zero_bytes(typed.Data(), 0, typed.ByteLength())) {              \
-            Napi::TypeError::New(env, "PublicKeyArg must not be zero key")     \
+            Napi::TypeError::New(                                              \
+                env, "BLST_ERROR: PublicKeyArg must not be zero key")          \
                 .ThrowAsJavaScriptException();                                 \
             has_error = true;                                                  \
         }                                                                      \
@@ -131,7 +137,8 @@ using std::endl;
         if (!wrapped.CheckTypeTag(&module->_##snake_case_name##_tag)) {        \
             Napi::TypeError::New(                                              \
                 env,                                                           \
-                pascal_case_string " must be a " pascal_case_string "Arg")     \
+                "BLST_ERROR: " pascal_case_string                              \
+                " must be a " pascal_case_string "Arg")                        \
                 .ThrowAsJavaScriptException();                                 \
             has_error = true;                                                  \
         }                                                                      \
@@ -141,7 +148,8 @@ using std::endl;
             if (!snake_case_name->_has_jacobian) {                             \
                 if (!snake_case_name->_has_affine) {                           \
                     Napi::Error::New(                                          \
-                        env, pascal_case_string " not initialized")            \
+                        env,                                                   \
+                        "BLST_ERROR: " pascal_case_string " not initialized")  \
                         .ThrowAsJavaScriptException();                         \
                     has_error = true;                                          \
                 }                                                              \
@@ -153,7 +161,8 @@ using std::endl;
             if (!snake_case_name->_has_affine) {                               \
                 if (!snake_case_name->_has_jacobian) {                         \
                     Napi::Error::New(                                          \
-                        env, pascal_case_string " not initialized")            \
+                        env,                                                   \
+                        "BLST_ERROR: " pascal_case_string " not initialized")  \
                         .ThrowAsJavaScriptException();                         \
                     has_error = true;                                          \
                 }                                                              \
@@ -167,7 +176,9 @@ using std::endl;
         ptr_group.raw_pointer = snake_case_name->member_name.get();            \
     } else {                                                                   \
         Napi::TypeError::New(                                                  \
-            env, pascal_case_string " must be a " pascal_case_string "Arg")    \
+            env,                                                               \
+            "BLST_ERROR: " pascal_case_string " must be a " pascal_case_string \
+            "Arg")                                                             \
             .ThrowAsJavaScriptException();                                     \
         has_error = true;                                                      \
     }
@@ -210,10 +221,10 @@ bool is_valid_length(
 /**
  * Circular dependency if these are moved up to the top of the file.
  */
+#include "functions.h"
 #include "public_key.h"
 #include "secret_key.h"
 #include "signature.h"
-#include "functions.h"
 
 /**
  * BlstTsAddon is the main entry point for the library. It is responsible

--- a/rebuild/src/functions.cc
+++ b/rebuild/src/functions.cc
@@ -42,16 +42,6 @@ Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
             if (has_error) {
                 return scope.Escape(env.Undefined());
             }
-            // TODO: Do we still need to check for 0x40 key?
-            // if (key_bytes[0] & 0x40 &&
-            //     this->IsZeroBytes(
-            //         key_bytes,
-            //         1,
-            //         _public_keys[_public_keys.GetBadIndex()]
-            //             .GetBytesLength())) {
-            //     _is_valid = false;
-            //     return;
-            // }
             result->_jacobian->add(*ptr_group.raw_pointer);
         } catch (const blst::BLST_ERROR &err) {
             std::ostringstream msg;

--- a/rebuild/src/functions.cc
+++ b/rebuild/src/functions.cc
@@ -4,14 +4,16 @@ namespace {
 Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)
     if (!info[0].IsArray()) {
-        Napi::TypeError::New(env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
     Napi::Array arr = info[0].As<Napi::Array>();
     uint32_t length = arr.Length();
     if (length == 0) {
-        Napi::TypeError::New(env, "BLST_ERROR: PublicKeyArg[] must have length > 0")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: PublicKeyArg[] must have length > 0")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
@@ -58,14 +60,16 @@ Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
 Napi::Value AggregateSignatures(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)
     if (!info[0].IsArray()) {
-        Napi::TypeError::New(env, "BLST_ERROR: signatures must be of type SignatureArg[]")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: signatures must be of type SignatureArg[]")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
     Napi::Array arr = info[0].As<Napi::Array>();
     uint32_t length = arr.Length();
     if (length == 0) {
-        Napi::TypeError::New(env, "BLST_ERROR: SignatureArg[] must have length > 0")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: SignatureArg[] must have length > 0")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
@@ -117,7 +121,8 @@ Napi::Value AggregateVerify(const Napi::CallbackInfo &info) {
         bool has_error = false;
 
         if (!info[0].IsArray()) {
-            Napi::TypeError::New(env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -157,7 +162,8 @@ Napi::Value AggregateVerify(const Napi::CallbackInfo &info) {
             if (sig_ptr_group.raw_pointer->is_inf()) {
                 return scope.Escape(Napi::Boolean::New(env, false));
             }
-            Napi::TypeError::New(env, "BLST_ERROR: publicKeys must have length > 0")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: publicKeys must have length > 0")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -244,22 +250,24 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
         for (uint32_t i = 0; i < sets_array_length; i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
             if (!module->GetRandomBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
-                Napi::Error::New(env, "BLST_ERROR: Failed to generate random bytes")
+                Napi::Error::New(
+                    env, "BLST_ERROR: Failed to generate random bytes")
                     .ThrowAsJavaScriptException();
                 return scope.Escape(env.Undefined());
             }
 
             Napi::Value set_value = sets_array[i];
             if (!set_value.IsObject()) {
-                Napi::TypeError::New(env, "BLST_ERROR: signatureSet must be an object")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: signatureSet must be an object")
                     .ThrowAsJavaScriptException();
                 return scope.Escape(env.Undefined());
             }
             Napi::Object set = set_value.As<Napi::Object>();
 
-            Napi::Value msg_value = set.Get("msg");
+            Napi::Value msg_value = set.Get("message");
             BLST_TS_UNWRAP_UINT_8_ARRAY(
-                msg_value, msg, "msg", scope.Escape(env.Undefined()))
+                msg_value, msg, "message", scope.Escape(env.Undefined()))
 
             Napi::Value pk_val = set.Get("publicKey");
             PointerGroup<blst::P1_Affine> pk_ptr_group;
@@ -357,15 +365,16 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
             for (uint32_t i = 0; i < sets_array_length; i++) {
                 Napi::Value set_value = sets_array[i];
                 if (!set_value.IsObject()) {
-                    Napi::Error::New(env, "BLST_ERROR: signatureSet must be an object")
+                    Napi::Error::New(
+                        env, "BLST_ERROR: signatureSet must be an object")
                         .ThrowAsJavaScriptException();
                     m_has_error = true;
                     return;
                 }
                 Napi::Object set = set_value.As<Napi::Object>();
 
-                Napi::Value msg_value = set.Get("msg");
-                BLST_TS_UNWRAP_UINT_8_ARRAY(msg_value, msg, "msg", )
+                Napi::Value msg_value = set.Get("message");
+                BLST_TS_UNWRAP_UINT_8_ARRAY(msg_value, msg, "message", )
 
                 m_sets.push_back(
                     {PointerGroup<blst::P1_Affine>(),
@@ -497,7 +506,8 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
         Napi::Env env = Env();
         try {
             if (!info[0].IsArray()) {
-                Napi::TypeError::New(env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
@@ -507,7 +517,8 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
 
             if (!info[1].IsArray()) {
                 Napi::TypeError::New(
-                    env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
+                    env,
+                    "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
@@ -539,20 +550,23 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
                     m_is_invalid = true;
                     return;
                 }
-                Napi::TypeError::New(env, "BLST_ERROR: publicKeys must have length > 0")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: publicKeys must have length > 0")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
             }
             if (msgs_array_length == 0) {
-                Napi::TypeError::New(env, "BLST_ERROR: msgs must have length > 0")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: msgs must have length > 0")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
             }
             if (msgs_array_length != pk_array_length) {
                 Napi::TypeError::New(
-                    env, "BLST_ERROR: msgs and publicKeys must be the same length")
+                    env,
+                    "BLST_ERROR: msgs and publicKeys must be the same length")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;

--- a/rebuild/src/functions.cc
+++ b/rebuild/src/functions.cc
@@ -4,14 +4,14 @@ namespace {
 Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)
     if (!info[0].IsArray()) {
-        Napi::TypeError::New(env, "publicKeys must be of type PublicKeyArg[]")
+        Napi::TypeError::New(env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
     Napi::Array arr = info[0].As<Napi::Array>();
     uint32_t length = arr.Length();
     if (length == 0) {
-        Napi::TypeError::New(env, "PublicKeyArg[] must have length > 0")
+        Napi::TypeError::New(env, "BLST_ERROR: PublicKeyArg[] must have length > 0")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
@@ -68,14 +68,14 @@ Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
 Napi::Value AggregateSignatures(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)
     if (!info[0].IsArray()) {
-        Napi::TypeError::New(env, "signatures must be of type SignatureArg[]")
+        Napi::TypeError::New(env, "BLST_ERROR: signatures must be of type SignatureArg[]")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
     Napi::Array arr = info[0].As<Napi::Array>();
     uint32_t length = arr.Length();
     if (length == 0) {
-        Napi::TypeError::New(env, "SignatureArg[] must have length > 0")
+        Napi::TypeError::New(env, "BLST_ERROR: SignatureArg[] must have length > 0")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
@@ -127,7 +127,7 @@ Napi::Value AggregateVerify(const Napi::CallbackInfo &info) {
         bool has_error = false;
 
         if (!info[0].IsArray()) {
-            Napi::TypeError::New(env, "msgs must be of type BlstBuffer[]")
+            Napi::TypeError::New(env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -167,18 +167,18 @@ Napi::Value AggregateVerify(const Napi::CallbackInfo &info) {
             if (sig_ptr_group.raw_pointer->is_inf()) {
                 return scope.Escape(Napi::Boolean::New(env, false));
             }
-            Napi::TypeError::New(env, "publicKeys must have length > 0")
+            Napi::TypeError::New(env, "BLST_ERROR: publicKeys must have length > 0")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
         if (msgs_array_length == 0) {
-            Napi::TypeError::New(env, "msgs must have length > 0")
+            Napi::TypeError::New(env, "BLST_ERROR: msgs must have length > 0")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
         if (msgs_array_length != pk_array_length) {
             Napi::TypeError::New(
-                env, "msgs and publicKeys must be the same length")
+                env, "BLST_ERROR: msgs and publicKeys must be the same length")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -242,7 +242,7 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
 
         if (!info[0].IsArray()) {
             Napi::TypeError::New(
-                env, "signatureSets must be of type SignatureSet[]")
+                env, "BLST_ERROR: signatureSets must be of type SignatureSet[]")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -254,14 +254,14 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
         for (uint32_t i = 0; i < sets_array_length; i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
             if (!module->GetRandomBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
-                Napi::Error::New(env, "Failed to generate random bytes")
+                Napi::Error::New(env, "BLST_ERROR: Failed to generate random bytes")
                     .ThrowAsJavaScriptException();
                 return scope.Escape(env.Undefined());
             }
 
             Napi::Value set_value = sets_array[i];
             if (!set_value.IsObject()) {
-                Napi::TypeError::New(env, "signatureSet must be an object")
+                Napi::TypeError::New(env, "BLST_ERROR: signatureSet must be an object")
                     .ThrowAsJavaScriptException();
                 return scope.Escape(env.Undefined());
             }
@@ -354,7 +354,7 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
         Napi::Env env = Env();
         if (!info[0].IsArray()) {
             Napi::Error::New(
-                env, "signatureSets must be of type SignatureSet[]")
+                env, "BLST_ERROR: signatureSets must be of type SignatureSet[]")
                 .ThrowAsJavaScriptException();
             m_has_error = true;
             return;
@@ -367,7 +367,7 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
             for (uint32_t i = 0; i < sets_array_length; i++) {
                 Napi::Value set_value = sets_array[i];
                 if (!set_value.IsObject()) {
-                    Napi::Error::New(env, "signatureSet must be an object")
+                    Napi::Error::New(env, "BLST_ERROR: signatureSet must be an object")
                         .ThrowAsJavaScriptException();
                     m_has_error = true;
                     return;
@@ -438,7 +438,7 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
         for (uint32_t i = 0; i < m_sets.size(); i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
             if (!m_module->GetRandomBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
-                SetError("Failed to generate random bytes");
+                SetError("BLST_ERROR: Failed to generate random bytes");
                 return;
             }
 
@@ -507,7 +507,7 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
         Napi::Env env = Env();
         try {
             if (!info[0].IsArray()) {
-                Napi::TypeError::New(env, "msgs must be of type BlstBuffer[]")
+                Napi::TypeError::New(env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
@@ -517,7 +517,7 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
 
             if (!info[1].IsArray()) {
                 Napi::TypeError::New(
-                    env, "publicKeys must be of type PublicKeyArg[]")
+                    env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
@@ -549,20 +549,20 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
                     m_is_invalid = true;
                     return;
                 }
-                Napi::TypeError::New(env, "publicKeys must have length > 0")
+                Napi::TypeError::New(env, "BLST_ERROR: publicKeys must have length > 0")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
             }
             if (msgs_array_length == 0) {
-                Napi::TypeError::New(env, "msgs must have length > 0")
+                Napi::TypeError::New(env, "BLST_ERROR: msgs must have length > 0")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
             }
             if (msgs_array_length != pk_array_length) {
                 Napi::TypeError::New(
-                    env, "msgs and publicKeys must be the same length")
+                    env, "BLST_ERROR: msgs and publicKeys must be the same length")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;

--- a/rebuild/src/public_key.cc
+++ b/rebuild/src/public_key.cc
@@ -59,7 +59,8 @@ Napi::Value PublicKey::Deserialize(const Napi::CallbackInfo &info) {
     if (!info[1].IsUndefined()) {
         Napi::Value type_val = info[1].As<Napi::Value>();
         if (!type_val.IsNumber()) {
-            Napi::TypeError::New(env, "BLST_ERROR: type must be of enum CoordType (number)")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: type must be of enum CoordType (number)")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }

--- a/rebuild/src/public_key.cc
+++ b/rebuild/src/public_key.cc
@@ -41,7 +41,7 @@ Napi::Value PublicKey::Deserialize(const Napi::CallbackInfo &info) {
 
     BLST_TS_UNWRAP_UINT_8_ARRAY(
         pk_bytes_value, pk_bytes, "pkBytes", scope.Escape(env.Undefined()))
-    std::string err_out{"pkBytes"};
+    std::string err_out{"BLST_ERROR: pkBytes"};
     if (!is_valid_length(
             err_out,
             pk_bytes.ByteLength(),
@@ -59,7 +59,7 @@ Napi::Value PublicKey::Deserialize(const Napi::CallbackInfo &info) {
     if (!info[1].IsUndefined()) {
         Napi::Value type_val = info[1].As<Napi::Value>();
         if (!type_val.IsNumber()) {
-            Napi::TypeError::New(env, "type must be of enum CoordType (number)")
+            Napi::TypeError::New(env, "BLST_ERROR: type must be of enum CoordType (number)")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -117,22 +117,22 @@ Napi::Value PublicKey::KeyValidate(const Napi::CallbackInfo &info) {
 
     if (_has_jacobian) {
         if (_jacobian->is_inf()) {
-            Napi::Error::New(env, "blst::BLST_PK_IS_INFINITY")
+            Napi::Error::New(env, "BLST_ERROR::BLST_PK_IS_INFINITY")
                 .ThrowAsJavaScriptException();
         } else if (!_jacobian->in_group()) {
-            Napi::Error::New(env, "blst::BLST_POINT_NOT_IN_GROUP")
+            Napi::Error::New(env, "BLST_ERROR::BLST_POINT_NOT_IN_GROUP")
                 .ThrowAsJavaScriptException();
         }
     } else if (_has_affine) {
         if (_affine->is_inf()) {
-            Napi::Error::New(env, "blst::BLST_PK_IS_INFINITY")
+            Napi::Error::New(env, "BLST_ERROR::BLST_PK_IS_INFINITY")
                 .ThrowAsJavaScriptException();
         } else if (!_affine->in_group()) {
-            Napi::Error::New(env, "blst::BLST_POINT_NOT_IN_GROUP")
+            Napi::Error::New(env, "BLST_ERROR::BLST_POINT_NOT_IN_GROUP")
                 .ThrowAsJavaScriptException();
         }
     } else {
-        Napi::Error::New(env, "blst::BLST_PK_IS_INFINITY")
+        Napi::Error::New(env, "BLST_ERROR::BLST_PK_IS_INFINITY")
             .ThrowAsJavaScriptException();
     }
 

--- a/rebuild/src/secret_key.cc
+++ b/rebuild/src/secret_key.cc
@@ -154,7 +154,8 @@ Napi::Value SecretKey::Sign(const Napi::CallbackInfo &info) {
 
     // Check for zero key and throw error to meet spec requirements
     if (_is_zero_key) {
-        Napi::TypeError::New(env, "BLST_ERROR: cannot sign message with zero private key")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: cannot sign message with zero private key")
             .ThrowAsJavaScriptException();
         return scope.Escape(info.Env().Undefined());
     }

--- a/rebuild/src/secret_key.cc
+++ b/rebuild/src/secret_key.cc
@@ -61,7 +61,7 @@ Napi::Value SecretKey::FromKeygen(const Napi::CallbackInfo &info) {
     // optional parameter from blst library.
     if (!info[1].IsUndefined()) {
         if (!info[1].IsString()) {
-            Napi::TypeError::New(env, "info must be a string")
+            Napi::TypeError::New(env, "BLST_ERROR: info must be a string")
                 .ThrowAsJavaScriptException();
             return env.Undefined();
         }
@@ -90,7 +90,7 @@ Napi::Value SecretKey::Deserialize(const Napi::CallbackInfo &info) {
     Napi::Value sk_bytes_value = info[0];
     BLST_TS_UNWRAP_UINT_8_ARRAY(
         sk_bytes_value, sk_bytes, "skBytes", scope.Escape(env.Undefined()))
-    std::string err_out{"skBytes"};
+    std::string err_out{"BLST_ERROR: skBytes"};
     if (!is_valid_length(
             err_out, sk_bytes.ByteLength(), BLST_TS_SECRET_KEY_LENGTH)) {
         Napi::TypeError::New(env, err_out).ThrowAsJavaScriptException();
@@ -154,7 +154,7 @@ Napi::Value SecretKey::Sign(const Napi::CallbackInfo &info) {
 
     // Check for zero key and throw error to meet spec requirements
     if (_is_zero_key) {
-        Napi::TypeError::New(env, "cannot sign message with zero private key")
+        Napi::TypeError::New(env, "BLST_ERROR: cannot sign message with zero private key")
             .ThrowAsJavaScriptException();
         return scope.Escape(info.Env().Undefined());
     }

--- a/rebuild/src/signature.cc
+++ b/rebuild/src/signature.cc
@@ -59,7 +59,8 @@ Napi::Value Signature::Deserialize(const Napi::CallbackInfo &info) {
     if (!info[1].IsUndefined()) {
         Napi::Value type_val = info[1].As<Napi::Value>();
         if (!type_val.IsNumber()) {
-            Napi::TypeError::New(env, "BLST_ERROR: type must be of enum CoordType (number)")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: type must be of enum CoordType (number)")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }

--- a/rebuild/src/signature.cc
+++ b/rebuild/src/signature.cc
@@ -41,7 +41,7 @@ Napi::Value Signature::Deserialize(const Napi::CallbackInfo &info) {
 
     BLST_TS_UNWRAP_UINT_8_ARRAY(
         sig_bytes_value, sig_bytes, "sigBytes", scope.Escape(env.Undefined()))
-    std::string err_out{"sigBytes"};
+    std::string err_out{"BLST_ERROR: sigBytes"};
     if (!is_valid_length(
             err_out,
             sig_bytes.ByteLength(),
@@ -59,7 +59,7 @@ Napi::Value Signature::Deserialize(const Napi::CallbackInfo &info) {
     if (!info[1].IsUndefined()) {
         Napi::Value type_val = info[1].As<Napi::Value>();
         if (!type_val.IsNumber()) {
-            Napi::TypeError::New(env, "type must be of enum CoordType (number)")
+            Napi::TypeError::New(env, "BLST_ERROR: type must be of enum CoordType (number)")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -111,13 +111,13 @@ Napi::Value Signature::SigValidate(const Napi::CallbackInfo &info) {
     Napi::EscapableHandleScope scope(env);
 
     if (!_has_jacobian && !_has_affine) {
-        Napi::Error::New(env, "Signature not initialized")
+        Napi::Error::New(env, "BLST_ERROR: Signature not initialized")
             .ThrowAsJavaScriptException();
     } else if (_has_jacobian && !_jacobian->in_group()) {
-        Napi::Error::New(env, "blst::BLST_POINT_NOT_IN_GROUP")
+        Napi::Error::New(env, "BLST_ERROR::BLST_POINT_NOT_IN_GROUP")
             .ThrowAsJavaScriptException();
     } else if (_has_affine && !_affine->in_group()) {
-        Napi::Error::New(env, "blst::BLST_POINT_NOT_IN_GROUP")
+        Napi::Error::New(env, "BLST_ERROR::BLST_POINT_NOT_IN_GROUP")
             .ThrowAsJavaScriptException();
     }
 

--- a/rebuild/test/__fixtures__/index.ts
+++ b/rebuild/test/__fixtures__/index.ts
@@ -1,4 +1,4 @@
-import {fromHex, getFilledUint8, makeNapiTestSet, makeNapiTestSets, sullyUint8Array} from "../utils";
+import {fromHex, getFilledUint8, makeNapiTestSet, makeNapiTestSets, sullyUint8Array} from "../utils.js";
 
 export const invalidInputs: [string, any][] = [
   ["boolean", true],
@@ -61,9 +61,9 @@ export const validSignature = {
 export const badSignature = sullyUint8Array(makeNapiTestSet().signature.serialize(false));
 
 export const validSignatureSet = makeNapiTestSets(1).map((set) => {
-  const {msg, secretKey, publicKey, signature} = set;
+  const {message, secretKey, publicKey, signature} = set;
   return {
-    msg,
+    message,
     secretKey,
     publicKey,
     signature,

--- a/rebuild/test/spec/downloadTests.ts
+++ b/rebuild/test/spec/downloadTests.ts
@@ -4,8 +4,12 @@ import path from "node:path";
 import {execSync} from "node:child_process";
 import tar from "tar";
 import fetch from "node-fetch";
-import {SPEC_TEST_LOCATION, SPEC_TEST_VERSION, SPEC_TEST_REPO_URL, SPEC_TEST_TO_DOWNLOAD} from "./specTestVersioning";
-
+import {
+  SPEC_TEST_LOCATION,
+  SPEC_TEST_VERSION,
+  SPEC_TEST_REPO_URL,
+  SPEC_TEST_TO_DOWNLOAD,
+} from "./specTestVersioning.js";
 
 const specVersion = SPEC_TEST_VERSION;
 const outputDir = SPEC_TEST_LOCATION;

--- a/rebuild/test/spec/downloadTests.ts
+++ b/rebuild/test/spec/downloadTests.ts
@@ -1,0 +1,68 @@
+/* eslint-disable no-console */
+import fs from "node:fs";
+import path from "node:path";
+import {execSync} from "node:child_process";
+import tar from "tar";
+import fetch from "node-fetch";
+import {SPEC_TEST_LOCATION, SPEC_TEST_VERSION, SPEC_TEST_REPO_URL, SPEC_TEST_TO_DOWNLOAD} from "./specTestVersioning";
+
+
+const specVersion = SPEC_TEST_VERSION;
+const outputDir = SPEC_TEST_LOCATION;
+const specTestsRepoUrl = SPEC_TEST_REPO_URL;
+
+const versionFile = path.join(outputDir, "version.txt");
+const existingVersion = fs.existsSync(versionFile) ? fs.readFileSync(versionFile, "utf8").trim() : "none";
+
+if (existingVersion === specVersion) {
+  console.log(`version ${specVersion} already downloaded`);
+  process.exit(0);
+} else {
+  console.log(`Downloading new version: ${specVersion} existingVersion: ${existingVersion}`);
+}
+
+if (fs.existsSync(outputDir)) {
+  console.log(`Cleaning existing version ${existingVersion} at ${outputDir}`);
+  shell(`rm -rf ${outputDir}`);
+}
+
+fs.mkdirSync(outputDir, {recursive: true});
+
+const urls = SPEC_TEST_TO_DOWNLOAD.map((test) => `${specTestsRepoUrl}/releases/download/${specVersion}/${test}.tar.gz`);
+
+downloadAndExtract(urls, outputDir)
+  .then(() => {
+    console.log("Downloads and extractions complete.");
+    fs.writeFileSync(versionFile, specVersion);
+  })
+  .catch((error) => {
+    console.error(`Error downloading test files: ${error}`);
+    process.exit(1);
+  });
+
+function shell(cmd: string): string {
+  try {
+    return execSync(cmd, {encoding: "utf8"}).trim();
+  } catch (error) {
+    console.error(`Error executing shell command: ${cmd}`);
+    throw error;
+  }
+}
+
+async function downloadAndExtract(urls: string[], outputDir: string): Promise<void> {
+  for (const url of urls) {
+    const fileName = url.split("/").pop();
+    const filePath = path.resolve(outputDir, String(fileName));
+    const response = await fetch(url);
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to download ${url}`);
+    }
+
+    await fs.promises.writeFile(filePath, response.body);
+
+    await tar.x({
+      file: filePath,
+      cwd: outputDir,
+    });
+  }
+}

--- a/rebuild/test/spec/index.test.ts
+++ b/rebuild/test/spec/index.test.ts
@@ -1,0 +1,227 @@
+import {expect} from "chai";
+import fs from "fs";
+import path from "path";
+import jsYaml from "js-yaml";
+import {SPEC_TEST_LOCATION} from "./specTestVersioning";
+import blst from "../../lib";
+import {fromHex, toHex} from "../utils";
+
+// Example full path
+// blst-ts/spec-tests/tests/general/altair/bls/eth_aggregate_pubkeys/small/eth_aggregate_pubkeys_empty_list
+
+const G2_POINT_AT_INFINITY =
+  "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+const G1_POINT_AT_INFINITY =
+  "0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+const testRootDirByFork = path.join(SPEC_TEST_LOCATION, "tests/general");
+for (const fork of fs.readdirSync(testRootDirByFork)) {
+  // fork = "phase0" | "altair"
+  const testRootDirFork = path.join(testRootDirByFork, fork, "bls");
+
+  for (const testType of fs.readdirSync(testRootDirFork)) {
+    // testType = "eth_aggregate_pubkeys" | "fast_aggregate_verify" | ...
+    const testTypeDir = path.join(testRootDirFork, testType);
+    describe(path.join(fork, testType), () => {
+      const testFnByType: Record<string, (data: any) => any> = {
+        aggregate,
+        aggregate_verify,
+        eth_aggregate_pubkeys,
+        eth_fast_aggregate_verify,
+        fast_aggregate_verify,
+        sign,
+        verify,
+      };
+      const testFn = testFnByType[testType];
+
+      before("Known testFn", () => {
+        if (!testFn) throw Error(`Unknown testFn ${testType}`);
+      });
+
+      for (const testCaseGroup of fs.readdirSync(testTypeDir)) {
+        // testCaseGroup = "small"
+        const testCaseGroupDir = path.join(testTypeDir, testCaseGroup);
+
+        for (const testCase of fs.readdirSync(testCaseGroupDir)) {
+          // testCase = "eth_aggregate_pubkeys_empty_list"
+          const testCaseDir = path.join(testCaseGroupDir, testCase);
+
+          it(testCase, () => {
+            // Ensure there are no unknown files
+            const files = fs.readdirSync(testCaseDir);
+            expect(files).to.deep.equal(["data.yaml"], `Unknown files in ${testCaseDir}`);
+
+            // Examples of parsed YAML
+            // {
+            //   input: [
+            //     '0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121',
+            //     '0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df',
+            //     '0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9'
+            //   ],
+            //   output: '0x9712c3edd73a209c742b8250759db12549b3eaf43b5ca61376d9f30e2747dbcf842d8b2ac0901d2a093713e20284a7670fcf6954e9ab93de991bb9b313e664785a075fc285806fa5224c82bde146561b446ccfc706a64b8579513cfc4ff1d930'
+            // }
+            //
+            // {
+            //   input: ['0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'],
+            //   output: null
+            // }
+            //
+            // {
+            //   input: ...,
+            //   output: false
+            // }
+
+            const testData = jsYaml.load(fs.readFileSync(path.join(testCaseDir, "data.yaml"), "utf8")) as {
+              input: unknown;
+              output: unknown;
+            };
+
+            if (process.env.DEBUG) {
+              // eslint-disable-next-line no-console
+              console.log(testData);
+            }
+
+            try {
+              expect(testFn(testData.input)).to.deep.equal(testData.output);
+            } catch (e) {
+              // spec test expect a boolean even for invalid inputs
+              if (!isBlstError(e)) throw e;
+
+              expect(false).to.deep.equal(Boolean(testData.output));
+            }
+          });
+        }
+      }
+    });
+  }
+}
+
+/**
+ * ```
+ * input: List[BLS Signature] -- list of input BLS signatures
+ * output: BLS Signature -- expected output, single BLS signature or empty.
+ * ```
+ */
+function aggregate(input: string[]): string | null {
+  const agg = blst.aggregateSignatures(input.map((hex) => blst.Signature.fromBytes(fromHex(hex))));
+  return toHex(agg.toBytes());
+}
+
+/**
+ * ```
+ * input:
+ *   pubkeys: List[BLS Pubkey] -- the pubkeys
+ *   messages: List[bytes32] -- the messages
+ *   signature: BLS Signature -- the signature to verify against pubkeys and messages
+ * output: bool  --  true (VALID) or false (INVALID)
+ * ```
+ */
+function aggregate_verify(input: {pubkeys: string[]; messages: string[]; signature: string}): boolean {
+  const {pubkeys, messages, signature} = input;
+  return blst.aggregateVerify(
+    messages.map(fromHex),
+    pubkeys.map((hex) => blst.PublicKey.fromBytes(fromHex(hex))),
+    blst.Signature.fromBytes(fromHex(signature))
+  );
+}
+
+/**
+ * ```
+ * input: List[BLS Signature] -- list of input BLS signatures
+ * output: BLS Signature -- expected output, single BLS signature or empty.
+ * ```
+ */
+function eth_aggregate_pubkeys(input: string[]): string | null {
+  // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
+  for (const pk of input) {
+    if (pk === G1_POINT_AT_INFINITY) return null;
+  }
+
+  const agg = blst.aggregatePubkeys(input.map((hex) => blst.PublicKey.fromBytes(fromHex(hex))));
+  return toHex(agg.toBytes());
+}
+
+/**
+ * ```
+ * input:
+ *   pubkeys: List[BLS Pubkey] -- list of input BLS pubkeys
+ *   message: bytes32 -- the message
+ *   signature: BLS Signature -- the signature to verify against pubkeys and message
+ * output: bool  --  true (VALID) or false (INVALID)
+ * ```
+ */
+function eth_fast_aggregate_verify(input: {pubkeys: string[]; message: string; signature: string}): boolean {
+  const {pubkeys, message, signature} = input;
+
+  if (pubkeys.length === 0 && signature === G2_POINT_AT_INFINITY) {
+    return true;
+  }
+
+  // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
+  for (const pk of pubkeys) {
+    if (pk === G1_POINT_AT_INFINITY) return false;
+  }
+
+  return blst.fastAggregateVerify(
+    fromHex(message),
+    pubkeys.map((hex) => blst.PublicKey.fromBytes(fromHex(hex))),
+    blst.Signature.fromBytes(fromHex(signature))
+  );
+}
+
+/**
+ * ```
+ * input:
+ *   pubkeys: List[BLS Pubkey] -- list of input BLS pubkeys
+ *   message: bytes32 -- the message
+ *   signature: BLS Signature -- the signature to verify against pubkeys and message
+ * output: bool  --  true (VALID) or false (INVALID)
+ * ```
+ */
+function fast_aggregate_verify(input: {pubkeys: string[]; message: string; signature: string}): boolean | null {
+  const {pubkeys, message, signature} = input;
+
+  // Don't add this checks in the source as beacon nodes check the pubkeys for inf when onboarding
+  for (const pk of pubkeys) {
+    if (pk === G1_POINT_AT_INFINITY) return false;
+  }
+
+  return blst.fastAggregateVerify(
+    fromHex(message),
+    pubkeys.map((hex) => blst.PublicKey.fromBytes(fromHex(hex))),
+    blst.Signature.fromBytes(fromHex(signature))
+  );
+}
+
+/**
+ * input:
+ *   privkey: bytes32 -- the private key used for signing
+ *   message: bytes32 -- input message to sign (a hash)
+ * output: BLS Signature -- expected output, single BLS signature or empty.
+ */
+function sign(input: {privkey: string; message: string}): string | null {
+  const {privkey, message} = input;
+  const sk = blst.SecretKey.fromBytes(fromHex(privkey));
+  const signature = sk.sign(fromHex(message));
+  return toHex(signature.toBytes());
+}
+
+/**
+ * input:
+ *   pubkey: bytes48 -- the pubkey
+ *   message: bytes32 -- the message
+ *   signature: bytes96 -- the signature to verify against pubkey and message
+ * output: bool  -- VALID or INVALID
+ */
+function verify(input: {pubkey: string; message: string; signature: string}): boolean {
+  const {pubkey, message, signature} = input;
+  return blst.verify(
+    fromHex(message),
+    blst.PublicKey.fromBytes(fromHex(pubkey)),
+    blst.Signature.fromBytes(fromHex(signature))
+  );
+}
+
+function isBlstError(e: unknown): boolean {
+  return (e as Error).message.includes("BLST_ERROR") || e instanceof blst.ErrorBLST;
+}

--- a/rebuild/test/spec/specTestVersioning.ts
+++ b/rebuild/test/spec/specTestVersioning.ts
@@ -1,0 +1,14 @@
+import path from "path";
+
+// WARNING! Don't move or rename this file !!!
+//
+// This file is used to generate the cache ID for spec tests download in Github Actions CI
+// It's path is hardcoded in: `.github/workflows/test-spec.yml`
+//
+// The contents of this file MUST include the URL, version and target path, and nothing else.
+
+export const SPEC_TEST_REPO_URL = "https://github.com/ethereum/consensus-spec-tests";
+export const SPEC_TEST_VERSION = "v1.3.0";
+export const SPEC_TEST_TO_DOWNLOAD = ["general" as const];
+// Target directory is the host package root: '<roo>/spec-tests'
+export const SPEC_TEST_LOCATION = path.join(__dirname, "../../spec-tests");

--- a/rebuild/test/spec/specTestVersioning.ts
+++ b/rebuild/test/spec/specTestVersioning.ts
@@ -1,4 +1,7 @@
-import path from "path";
+import {join, dirname} from "path";
+import {fileURLToPath} from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // WARNING! Don't move or rename this file !!!
 //
@@ -11,4 +14,4 @@ export const SPEC_TEST_REPO_URL = "https://github.com/ethereum/consensus-spec-te
 export const SPEC_TEST_VERSION = "v1.3.0";
 export const SPEC_TEST_TO_DOWNLOAD = ["general" as const];
 // Target directory is the host package root: '<roo>/spec-tests'
-export const SPEC_TEST_LOCATION = path.join(__dirname, "../../spec-tests");
+export const SPEC_TEST_LOCATION = join(__dirname, "../../spec-tests");

--- a/rebuild/test/types.ts
+++ b/rebuild/test/types.ts
@@ -1,9 +1,9 @@
-import * as bindings from "../lib";
+import * as bindings from "../lib/index.js";
 
 export type BufferLike = string | bindings.BlstBuffer;
 
 export interface NapiTestSet {
-  msg: Uint8Array;
+  message: Uint8Array;
   secretKey: bindings.SecretKey;
   publicKey: bindings.PublicKey;
   signature: bindings.Signature;

--- a/rebuild/test/unit/PublicKey.test.ts
+++ b/rebuild/test/unit/PublicKey.test.ts
@@ -1,7 +1,13 @@
 import {expect} from "chai";
-import {BLST_CONSTANTS, CoordType, PublicKey, SecretKey} from "../../lib";
-import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils";
-import {validPublicKey, SECRET_KEY_BYTES, invalidInputs, badPublicKey, G1_POINT_AT_INFINITY} from "../__fixtures__";
+import {BLST_CONSTANTS, CoordType, PublicKey, SecretKey} from "../../lib/index.js";
+import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils.js";
+import {
+  validPublicKey,
+  SECRET_KEY_BYTES,
+  invalidInputs,
+  badPublicKey,
+  G1_POINT_AT_INFINITY,
+} from "../__fixtures__/index.js";
 
 describe("PublicKey", () => {
   it("should exist", () => {

--- a/rebuild/test/unit/SecretKey.test.ts
+++ b/rebuild/test/unit/SecretKey.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {PublicKey, SecretKey, Signature, BLST_CONSTANTS} from "../../lib";
-import {KEY_MATERIAL, SECRET_KEY_BYTES, invalidInputs} from "../__fixtures__";
-import {expectEqualHex, expectNotEqualHex} from "../utils";
+import {PublicKey, SecretKey, Signature, BLST_CONSTANTS} from "../../lib/index.js";
+import {KEY_MATERIAL, SECRET_KEY_BYTES, invalidInputs} from "../__fixtures__/index.js";
+import {expectEqualHex, expectNotEqualHex} from "../utils.js";
 
 describe("SecretKey", () => {
   it("should exist", () => {

--- a/rebuild/test/unit/Signature.test.ts
+++ b/rebuild/test/unit/Signature.test.ts
@@ -48,38 +48,38 @@ describe("Signature", () => {
         expect(() => Signature.deserialize(sullyUint8Array(validSignature.compressed))).to.throw("BLST_BAD_ENCODING");
       });
     });
-    describe("methods", () => {
-      describe("serialize", () => {
-        const sig = SecretKey.fromKeygen(KEY_MATERIAL).sign(Buffer.from("some fancy message"));
-        it("should default to compressed serialization", () => {
-          expectEqualHex(sig.serialize(), sig.serialize(true));
-          expectNotEqualHex(sig.serialize(), sig.serialize(false));
-        });
-        it("should serialize compressed to the correct length", () => {
-          expect(sig.serialize(true)).to.have.lengthOf(BLST_CONSTANTS.SIGNATURE_LENGTH_COMPRESSED);
-        });
-        it("should serialize uncompressed to the correct length", () => {
-          expect(sig.serialize(false)).to.have.lengthOf(BLST_CONSTANTS.SIGNATURE_LENGTH_UNCOMPRESSED);
-        });
-        it("should serialize affine and jacobian points to the same value", () => {
-          const jacobian = Signature.deserialize(sig.serialize(), CoordType.jacobian);
-          const affine = Signature.deserialize(sig.serialize(), CoordType.affine);
-          expectEqualHex(jacobian.serialize(true), affine.serialize(true));
-          expectEqualHex(jacobian.serialize(false), affine.serialize(false));
-        });
+  });
+  describe("methods", () => {
+    describe("serialize", () => {
+      const sig = SecretKey.fromKeygen(KEY_MATERIAL).sign(Buffer.from("some fancy message"));
+      it("should default to compressed serialization", () => {
+        expectEqualHex(sig.serialize(), sig.serialize(true));
+        expectNotEqualHex(sig.serialize(), sig.serialize(false));
       });
-      describe("sigValidate()", () => {
-        it("should return undefined for valid", () => {
-          const sig = Signature.deserialize(validSignature.compressed);
-          expect(sig.sigValidate()).to.be.undefined;
-        });
-        it("should throw for invalid", () => {
-          const pkSeed = Signature.deserialize(validSignature.compressed);
-          const sig = Signature.deserialize(
-            Uint8Array.from([...pkSeed.serialize().subarray(0, 94), ...Buffer.from("a1")])
-          );
-          expect(() => sig.sigValidate()).to.throw("blst::BLST_POINT_NOT_IN_GROUP");
-        });
+      it("should serialize compressed to the correct length", () => {
+        expect(sig.serialize(true)).to.have.lengthOf(BLST_CONSTANTS.SIGNATURE_LENGTH_COMPRESSED);
+      });
+      it("should serialize uncompressed to the correct length", () => {
+        expect(sig.serialize(false)).to.have.lengthOf(BLST_CONSTANTS.SIGNATURE_LENGTH_UNCOMPRESSED);
+      });
+      it("should serialize affine and jacobian points to the same value", () => {
+        const jacobian = Signature.deserialize(sig.serialize(), CoordType.jacobian);
+        const affine = Signature.deserialize(sig.serialize(), CoordType.affine);
+        expectEqualHex(jacobian.serialize(true), affine.serialize(true));
+        expectEqualHex(jacobian.serialize(false), affine.serialize(false));
+      });
+    });
+    describe("sigValidate()", () => {
+      it("should return undefined for valid", () => {
+        const sig = Signature.deserialize(validSignature.compressed);
+        expect(sig.sigValidate()).to.be.undefined;
+      });
+      it("should throw for invalid", () => {
+        const pkSeed = Signature.deserialize(validSignature.compressed);
+        const sig = Signature.deserialize(
+          Uint8Array.from([...pkSeed.serialize().subarray(0, 94), ...Buffer.from("a1")])
+        );
+        expect(() => sig.sigValidate()).to.throw("BLST_ERROR::BLST_POINT_NOT_IN_GROUP");
       });
     });
   });

--- a/rebuild/test/unit/Signature.test.ts
+++ b/rebuild/test/unit/Signature.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {BLST_CONSTANTS, CoordType, SecretKey, Signature} from "../../lib";
-import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils";
-import {KEY_MATERIAL, invalidInputs, validSignature} from "../__fixtures__";
+import {BLST_CONSTANTS, CoordType, SecretKey, Signature} from "../../lib/index.js";
+import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils.js";
+import {KEY_MATERIAL, invalidInputs, validSignature} from "../__fixtures__/index.js";
 
 describe("Signature", () => {
   it("should exist", () => {

--- a/rebuild/test/unit/aggregatePublicKeys.test.ts
+++ b/rebuild/test/unit/aggregatePublicKeys.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {aggregatePublicKeys, PublicKey} from "../../lib";
-import {isEqualBytes, makeNapiTestSets} from "../utils";
-import {badPublicKey} from "../__fixtures__";
+import {aggregatePublicKeys, PublicKey} from "../../lib/index.js";
+import {isEqualBytes, makeNapiTestSets} from "../utils.js";
+import {badPublicKey} from "../__fixtures__/index.js";
 
 describe("Aggregate Public Keys", () => {
   const sets = makeNapiTestSets(10);

--- a/rebuild/test/unit/aggregateSignatures.test.ts
+++ b/rebuild/test/unit/aggregateSignatures.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {aggregateSignatures, Signature} from "../../lib";
-import {isEqualBytes, makeNapiTestSets} from "../utils";
-import {badSignature} from "../__fixtures__";
+import {aggregateSignatures, Signature} from "../../lib/index.js";
+import {isEqualBytes, makeNapiTestSets} from "../utils.js";
+import {badSignature} from "../__fixtures__/index.js";
 
 describe("Aggregate Signatures", () => {
   const sets = makeNapiTestSets(10);

--- a/rebuild/test/unit/bindings.test.ts
+++ b/rebuild/test/unit/bindings.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import * as bindings from "../../lib";
+import * as bindings from "../../lib/index.js";
 
 describe("bindings", () => {
   describe("exports", () => {

--- a/rebuild/test/unit/verify.test.ts
+++ b/rebuild/test/unit/verify.test.ts
@@ -6,9 +6,9 @@ import {
   asyncVerify,
   fastAggregateVerify,
   verify,
-} from "../../lib";
-import {sullyUint8Array, makeNapiTestSets} from "../utils";
-import {NapiTestSet} from "../types";
+} from "../../lib/index.js";
+import {sullyUint8Array, makeNapiTestSets} from "../utils.js";
+import {NapiTestSet} from "../types.js";
 
 describe("Verify", () => {
   let testSet: NapiTestSet;
@@ -17,33 +17,33 @@ describe("Verify", () => {
   });
   describe("verify", () => {
     it("should return a boolean", () => {
-      expect(verify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.a("boolean");
+      expect(verify(testSet.message, testSet.publicKey, testSet.signature)).to.be.a("boolean");
     });
     it("should default to false", () => {
-      expect(verify(sullyUint8Array(testSet.msg), testSet.publicKey, testSet.signature)).to.be.false;
-      expect(verify(testSet.msg, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be.false;
-      expect(verify(testSet.msg, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be.false;
+      expect(verify(sullyUint8Array(testSet.message), testSet.publicKey, testSet.signature)).to.be.false;
+      expect(verify(testSet.message, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be.false;
+      expect(verify(testSet.message, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be.false;
     });
     it("should return true for valid sets", () => {
-      expect(verify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+      expect(verify(testSet.message, testSet.publicKey, testSet.signature)).to.be.true;
     });
   });
   describe("asyncVerify", () => {
     it("should return Promise<boolean>", async () => {
-      const resPromise = asyncVerify(testSet.msg, testSet.publicKey, testSet.signature);
+      const resPromise = asyncVerify(testSet.message, testSet.publicKey, testSet.signature);
       expect(resPromise).to.be.instanceOf(Promise);
       const res = await resPromise;
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncVerify(sullyUint8Array(testSet.msg), testSet.publicKey, testSet.signature)).to.be.false;
-      expect(await asyncVerify(testSet.msg, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be
-        .false;
-      expect(await asyncVerify(testSet.msg, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be
-        .false;
+      expect(await asyncVerify(sullyUint8Array(testSet.message), testSet.publicKey, testSet.signature)).to.be.false;
+      expect(await asyncVerify(testSet.message, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to
+        .be.false;
+      expect(await asyncVerify(testSet.message, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to
+        .be.false;
     });
     it("should return true for valid sets", async () => {
-      expect(await asyncVerify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+      expect(await asyncVerify(testSet.message, testSet.publicKey, testSet.signature)).to.be.true;
     });
   });
 });
@@ -55,38 +55,46 @@ describe("Aggregate Verify", () => {
   });
   describe("aggregateVerify", () => {
     it("should return a boolean", () => {
-      expect(aggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.a("boolean");
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.a("boolean");
     });
     it("should default to false", () => {
-      expect(aggregateVerify([sullyUint8Array(testSet.msg)], [testSet.publicKey], testSet.signature)).to.be.false;
-      expect(aggregateVerify([testSet.msg], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to.be
-        .false;
-      expect(aggregateVerify([testSet.msg], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to.be
-        .false;
+      expect(aggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to.be.false;
+      expect(aggregateVerify([testSet.message], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
+        .be.false;
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
+        .be.false;
     });
     it("should return true for valid sets", () => {
-      expect(aggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
   describe("asyncAggregateVerify", () => {
     it("should return Promise<boolean>", async () => {
-      const resPromise = asyncAggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature);
+      const resPromise = asyncAggregateVerify([testSet.message], [testSet.publicKey], testSet.signature);
       expect(resPromise).to.be.instanceOf(Promise);
       const res = await resPromise;
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncAggregateVerify([sullyUint8Array(testSet.msg)], [testSet.publicKey], testSet.signature)).to.be
-        .false;
+      expect(await asyncAggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to
+        .be.false;
       expect(
-        await asyncAggregateVerify([testSet.msg], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
+        await asyncAggregateVerify(
+          [testSet.message],
+          [sullyUint8Array(testSet.publicKey.serialize())],
+          testSet.signature
+        )
       ).to.be.false;
       expect(
-        await asyncAggregateVerify([testSet.msg], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
+        await asyncAggregateVerify(
+          [testSet.message],
+          [testSet.publicKey],
+          sullyUint8Array(testSet.signature.serialize())
+        )
       ).to.be.false;
     });
     it("should return true for valid sets", async () => {
-      expect(await asyncAggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(await asyncAggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
 });
@@ -98,38 +106,46 @@ describe("Fast Aggregate Verify", () => {
   });
   describe("fastAggregateVerify", () => {
     it("should return a boolean", () => {
-      expect(fastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature)).to.be.a("boolean");
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.a("boolean");
     });
     it("should default to false", () => {
-      expect(fastAggregateVerify(sullyUint8Array(testSet.msg), [testSet.publicKey], testSet.signature)).to.be.false;
-      expect(fastAggregateVerify(testSet.msg, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
-        .be.false;
-      expect(fastAggregateVerify(testSet.msg, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
-        .be.false;
+      expect(fastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature)).to.be.false;
+      expect(fastAggregateVerify(testSet.message, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature))
+        .to.be.false;
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize())))
+        .to.be.false;
     });
     it("should return true for valid sets", () => {
-      expect(fastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
   describe("asyncFastAggregateVerify", () => {
     it("should return Promise<boolean>", async () => {
-      const resPromise = asyncFastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature);
+      const resPromise = asyncFastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature);
       expect(resPromise).to.be.instanceOf(Promise);
       const res = await resPromise;
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncFastAggregateVerify(sullyUint8Array(testSet.msg), [testSet.publicKey], testSet.signature)).to.be
-        .false;
+      expect(await asyncFastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature))
+        .to.be.false;
       expect(
-        await asyncFastAggregateVerify(testSet.msg, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
+        await asyncFastAggregateVerify(
+          testSet.message,
+          [sullyUint8Array(testSet.publicKey.serialize())],
+          testSet.signature
+        )
       ).to.be.false;
       expect(
-        await asyncFastAggregateVerify(testSet.msg, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
+        await asyncFastAggregateVerify(
+          testSet.message,
+          [testSet.publicKey],
+          sullyUint8Array(testSet.signature.serialize())
+        )
       ).to.be.false;
     });
     it("should return true for valid sets", async () => {
-      expect(await asyncFastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(await asyncFastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
 });

--- a/rebuild/test/unit/verifyMultipleAggregateSignatures.test.ts
+++ b/rebuild/test/unit/verifyMultipleAggregateSignatures.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
-import {asyncVerifyMultipleAggregateSignatures, verifyMultipleAggregateSignatures} from "../../lib";
-import {makeNapiTestSets} from "../utils";
+import {asyncVerifyMultipleAggregateSignatures, verifyMultipleAggregateSignatures} from "../../lib/index.js";
+import {makeNapiTestSets} from "../utils.js";
 
 describe("Verify Multiple Aggregate Signatures", () => {
   describe("verifyMultipleAggregateSignatures", () => {

--- a/rebuild/test/utils.ts
+++ b/rebuild/test/utils.ts
@@ -10,22 +10,22 @@ function toHexString(bytes: BufferLike): string {
   throw Error("toHexString only accepts BufferLike types");
 }
 
-export function normalizeHex(bytes: BufferLike): string {
+export function toHex(bytes: BufferLike): string {
   const hex = toHexString(bytes);
   if (hex.startsWith("0x")) return hex;
   return "0x" + hex;
 }
 
 export function isEqualBytes(value: BufferLike, expected: BufferLike): boolean {
-  return normalizeHex(value) === normalizeHex(expected);
+  return toHex(value) === toHex(expected);
 }
 
 export function expectEqualHex(value: BufferLike, expected: BufferLike): void {
-  expect(normalizeHex(value)).to.equal(normalizeHex(expected));
+  expect(toHex(value)).to.equal(toHex(expected));
 }
 
 export function expectNotEqualHex(value: BufferLike, expected: BufferLike): void {
-  expect(normalizeHex(value)).to.not.equal(normalizeHex(expected));
+  expect(toHex(value)).to.not.equal(toHex(expected));
 }
 
 export function fromHex(hexString: string): Uint8Array {

--- a/rebuild/test/utils.ts
+++ b/rebuild/test/utils.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {randomFillSync} from "crypto";
-import * as bindings from "../lib";
-import {BufferLike, NapiTestSet} from "./types";
+import * as bindings from "../lib/index.js";
+import {BufferLike, NapiTestSet} from "./types.js";
 
 function toHexString(bytes: BufferLike): string {
   if (typeof bytes === "string") return bytes;
@@ -45,22 +45,22 @@ export function sullyUint8Array(bytes: Uint8Array): Uint8Array {
 
 const DEFAULT_TEST_MESSAGE = Uint8Array.from(Buffer.from("test-message"));
 
-export function makeNapiTestSet(msg: Uint8Array = DEFAULT_TEST_MESSAGE): NapiTestSet {
+export function makeNapiTestSet(message: Uint8Array = DEFAULT_TEST_MESSAGE): NapiTestSet {
   const secretKey = bindings.SecretKey.fromKeygen(randomFillSync(Buffer.alloc(32)));
   const publicKey = secretKey.toPublicKey();
-  const signature = secretKey.sign(msg);
+  const signature = secretKey.sign(message);
   return {
-    msg,
+    message,
     secretKey,
     publicKey,
     signature,
   };
 }
 
-export function makeNapiTestSets(numSets: number, msg = DEFAULT_TEST_MESSAGE): NapiTestSet[] {
+export function makeNapiTestSets(numSets: number, message = DEFAULT_TEST_MESSAGE): NapiTestSet[] {
   const sets: NapiTestSet[] = [];
   for (let i = 0; i < numSets; i++) {
-    sets.push(makeNapiTestSet(msg));
+    sets.push(makeNapiTestSet(message));
   }
   return sets;
 }

--- a/rebuild/tsconfig.json
+++ b/rebuild/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": true,
     "target": "esnext",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext"],
 
     "strict": true,


### PR DESCRIPTION
Add spec tests for the rebuild folder

## Inclusions
- rebuild/test/spec folder
- add `BLST_ERROR:` prefix to all errors for catch in spec test