### PR TITLE
feat(rebuild): fixes from implementation into lodestar

### DIFF
--- a/rebuild/.eslintrc.cjs
+++ b/rebuild/.eslintrc.cjs
@@ -11,8 +11,12 @@ module.exports = {
   },
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    ecmaVersion: 10,
+    ecmaVersion: 12,
     project: "./tsconfig.json",
+    sourceType: "module",
+    ecmaFeatures:{
+      modules: true
+    }
   },
   plugins: ["@typescript-eslint", "eslint-plugin-import", "eslint-plugin-node", "prettier"],
   extends: [
@@ -51,6 +55,7 @@ module.exports = {
     "@typescript-eslint/explicit-member-accessibility": ["error", {accessibility: "no-public"}],
     "@typescript-eslint/no-unsafe-call": "error",
     "@typescript-eslint/no-unsafe-return": "error",
+    "import/no-unresolved": "off",
     "import/no-extraneous-dependencies": [
       "error",
       {
@@ -79,6 +84,12 @@ module.exports = {
   },
   settings: {
     "import/core-modules": ["node:child_process", "node:crypto", "node:fs", "node:os", "node:path", "node:util"],
+    'import/resolver': {
+      node: {
+        extensions: [".js", ".ts"],
+        moduleDirectory: ["lib/", "test/", "node_modules/"]
+      }
+    },
   },
   overrides: [
     {

--- a/rebuild/.mocharc.cjs
+++ b/rebuild/.mocharc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  colors: true,
+  require: "ts-node/register",
+  exit: true,
+  loader: "ts-node/esm"
+}

--- a/rebuild/.mocharc.yaml
+++ b/rebuild/.mocharc.yaml
@@ -1,3 +1,0 @@
-colors: true
-require: ts-node/register
-exit: true

--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -16,7 +16,7 @@ export type BlstBuffer = Uint8Array;
 export type PublicKeyArg = BlstBuffer | PublicKey;
 export type SignatureArg = BlstBuffer | Signature;
 export interface SignatureSet {
-  msg: BlstBuffer;
+  message: BlstBuffer;
   publicKey: PublicKeyArg;
   signature: SignatureArg;
 }

--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -71,6 +71,7 @@ export class SecretKey implements Serializable {
    * Serialize a secret key into a Buffer.
    */
   serialize(): Buffer;
+  toHex(): string;
   toPublicKey(): PublicKey;
   sign(msg: BlstBuffer): Signature;
 }
@@ -79,6 +80,7 @@ export class PublicKey implements Serializable {
   private constructor();
   static deserialize(skBytes: BlstBuffer, coordType?: CoordType): PublicKey;
   serialize(compress?: boolean): Buffer;
+  toHex(compress?: boolean): string;
   keyValidate(): void;
 }
 
@@ -86,6 +88,7 @@ export class Signature implements Serializable {
   private constructor();
   static deserialize(skBytes: BlstBuffer, coordType?: CoordType): Signature;
   serialize(compress?: boolean): Buffer;
+  toHex(compress?: boolean): string;
   sigValidate(): void;
 }
 

--- a/rebuild/lib/index.js
+++ b/rebuild/lib/index.js
@@ -3,41 +3,78 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
-const bindings = require("bindings")("blst_ts_addon");
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+const {default: getBindings} = await import("bindings");
+const bindings = getBindings("blst_ts_addon");
+const {
+  BLST_CONSTANTS,
+  SecretKey,
+  PublicKey,
+  Signature,
+  aggregatePublicKeys,
+  aggregateSignatures,
+  aggregateVerify,
+  verifyMultipleAggregateSignatures,
+  asyncAggregateVerify,
+  asyncVerifyMultipleAggregateSignatures,
+} = bindings;
 
-bindings.verify = function verify(msg, pk, sig) {
-  return bindings.aggregateVerify([msg], [pk], sig);
+SecretKey.prototype.toHex = function () {
+  return `0x${this.serialize().toString("hex")}`;
 };
 
-bindings.asyncVerify = function asyncVerify(msg, pk, sig) {
-  return bindings.asyncAggregateVerify([msg], [pk], sig);
+PublicKey.prototype.toHex = function (compress) {
+  return `0x${this.serialize(compress).toString("hex")}`;
 };
 
-bindings.fastAggregateVerify = function fastAggregateVerify(msg, pks, sig) {
+Signature.prototype.toHex = function (compress) {
+  return `0x${this.serialize(compress).toString("hex")}`;
+};
+
+export {
+  BLST_CONSTANTS,
+  SecretKey,
+  PublicKey,
+  Signature,
+  aggregatePublicKeys,
+  aggregateSignatures,
+  aggregateVerify,
+  verifyMultipleAggregateSignatures,
+  asyncAggregateVerify,
+  asyncVerifyMultipleAggregateSignatures,
+};
+
+export function verify(msg, pk, sig) {
+  return aggregateVerify([msg], [pk], sig);
+}
+
+export function asyncVerify(msg, pk, sig) {
+  return asyncAggregateVerify([msg], [pk], sig);
+}
+
+export function fastAggregateVerify(msg, pks, sig) {
   let key;
   try {
     // this throws for invalid key, catch and return false
-    key = bindings.aggregatePublicKeys(pks);
+    key = aggregatePublicKeys(pks);
   } catch {
     return false;
   }
-  return bindings.aggregateVerify([msg], [key], sig);
-};
+  return aggregateVerify([msg], [key], sig);
+}
 
-bindings.asyncFastAggregateVerify = function asyncFastAggregateVerify(msg, pks, sig) {
+export function asyncFastAggregateVerify(msg, pks, sig) {
   let key;
   try {
     // this throws for invalid key, catch and return false
-    key = bindings.aggregatePublicKeys(pks);
+    key = aggregatePublicKeys(pks);
   } catch {
     return false;
   }
-  return bindings.asyncAggregateVerify([msg], [key], sig);
-};
+  return asyncAggregateVerify([msg], [key], sig);
+}
 
-bindings.CoordType = {
+export const CoordType = {
   affine: 0,
   jacobian: 1,
 };
-
-module.exports = exports = bindings;

--- a/rebuild/lib/index.js
+++ b/rebuild/lib/index.js
@@ -78,3 +78,21 @@ export const CoordType = {
   affine: 0,
   jacobian: 1,
 };
+
+export default {
+  CoordType,
+  BLST_CONSTANTS,
+  SecretKey,
+  PublicKey,
+  Signature,
+  aggregatePublicKeys,
+  aggregateSignatures,
+  verify,
+  aggregateVerify,
+  fastAggregateVerify,
+  verifyMultipleAggregateSignatures,
+  asyncVerify,
+  asyncAggregateVerify,
+  asyncFastAggregateVerify,
+  asyncVerifyMultipleAggregateSignatures,
+};

--- a/rebuild/package.json
+++ b/rebuild/package.json
@@ -2,8 +2,6 @@
   "name": "@chainsafe/blst-ts",
   "version": "1.0.0",
   "description": "Typescript wrapper for supranational/blst native bindings, a highly performant BLS12-381 signature library",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "gypfile": true,
   "private": false,
   "files": [
@@ -12,6 +10,26 @@
     "lib",
     "src"
   ],
+  "type": "module",
+  "main": "./import/index.js",
+  "module": "./import/index.js",
+  "types": "./import/index.d.ts",
+  "exports": {
+    ".": "./import/index.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./import/index.d.ts"
+      ]
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./import/index.js"
+    },
+    "types": "./import/index.d.ts"
+  },
   "scripts": {
     "preinstall": "mkdir -p deps && cp -r ../blst deps",
     "clean": "npm run clean:dist; npm run clean:build",
@@ -24,7 +42,7 @@
     "lint:ts": "eslint --color --ext .ts lib/ test/",
     "lint:c": "clang-format -i ./src/*",
     "lint": "npm run lint:c && npm run lint:ts",
-    "test": "yarn test:unit",
+    "test": "yarn test:unit && yarn test:spec",
     "test:unit": "mocha test/unit/**/*.test.ts",
     "test:spec": "mocha 'test/spec/**/*.test.ts'",
     "download-spec-tests": "node -r ts-node/register test/spec/downloadTests.ts"

--- a/rebuild/src/addon.cc
+++ b/rebuild/src/addon.cc
@@ -62,7 +62,8 @@ BlstTsAddon::BlstTsAddon(Napi::Env env, Napi::Object exports)
     // Check that openssl PRNG is seeded
     blst::byte seed{0};
     if (!this->GetRandomBytes(&seed, 0)) {
-        Napi::Error::New(env, "BLST_ERROR: Error seeding pseudo-random number generator")
+        Napi::Error::New(
+            env, "BLST_ERROR: Error seeding pseudo-random number generator")
             .ThrowAsJavaScriptException();
     }
 }

--- a/rebuild/src/functions.cc
+++ b/rebuild/src/functions.cc
@@ -4,14 +4,16 @@ namespace {
 Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)
     if (!info[0].IsArray()) {
-        Napi::TypeError::New(env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
     Napi::Array arr = info[0].As<Napi::Array>();
     uint32_t length = arr.Length();
     if (length == 0) {
-        Napi::TypeError::New(env, "BLST_ERROR: PublicKeyArg[] must have length > 0")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: PublicKeyArg[] must have length > 0")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
@@ -58,14 +60,16 @@ Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
 Napi::Value AggregateSignatures(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)
     if (!info[0].IsArray()) {
-        Napi::TypeError::New(env, "BLST_ERROR: signatures must be of type SignatureArg[]")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: signatures must be of type SignatureArg[]")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
     Napi::Array arr = info[0].As<Napi::Array>();
     uint32_t length = arr.Length();
     if (length == 0) {
-        Napi::TypeError::New(env, "BLST_ERROR: SignatureArg[] must have length > 0")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: SignatureArg[] must have length > 0")
             .ThrowAsJavaScriptException();
         return scope.Escape(env.Undefined());
     }
@@ -117,7 +121,8 @@ Napi::Value AggregateVerify(const Napi::CallbackInfo &info) {
         bool has_error = false;
 
         if (!info[0].IsArray()) {
-            Napi::TypeError::New(env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -157,7 +162,8 @@ Napi::Value AggregateVerify(const Napi::CallbackInfo &info) {
             if (sig_ptr_group.raw_pointer->is_inf()) {
                 return scope.Escape(Napi::Boolean::New(env, false));
             }
-            Napi::TypeError::New(env, "BLST_ERROR: publicKeys must have length > 0")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: publicKeys must have length > 0")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }
@@ -244,14 +250,16 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
         for (uint32_t i = 0; i < sets_array_length; i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
             if (!module->GetRandomBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
-                Napi::Error::New(env, "BLST_ERROR: Failed to generate random bytes")
+                Napi::Error::New(
+                    env, "BLST_ERROR: Failed to generate random bytes")
                     .ThrowAsJavaScriptException();
                 return scope.Escape(env.Undefined());
             }
 
             Napi::Value set_value = sets_array[i];
             if (!set_value.IsObject()) {
-                Napi::TypeError::New(env, "BLST_ERROR: signatureSet must be an object")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: signatureSet must be an object")
                     .ThrowAsJavaScriptException();
                 return scope.Escape(env.Undefined());
             }
@@ -357,7 +365,8 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
             for (uint32_t i = 0; i < sets_array_length; i++) {
                 Napi::Value set_value = sets_array[i];
                 if (!set_value.IsObject()) {
-                    Napi::Error::New(env, "BLST_ERROR: signatureSet must be an object")
+                    Napi::Error::New(
+                        env, "BLST_ERROR: signatureSet must be an object")
                         .ThrowAsJavaScriptException();
                     m_has_error = true;
                     return;
@@ -497,7 +506,8 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
         Napi::Env env = Env();
         try {
             if (!info[0].IsArray()) {
-                Napi::TypeError::New(env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: msgs must be of type BlstBuffer[]")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
@@ -507,7 +517,8 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
 
             if (!info[1].IsArray()) {
                 Napi::TypeError::New(
-                    env, "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
+                    env,
+                    "BLST_ERROR: publicKeys must be of type PublicKeyArg[]")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
@@ -539,20 +550,23 @@ class AggregateVerifyWorker : public Napi::AsyncWorker {
                     m_is_invalid = true;
                     return;
                 }
-                Napi::TypeError::New(env, "BLST_ERROR: publicKeys must have length > 0")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: publicKeys must have length > 0")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
             }
             if (msgs_array_length == 0) {
-                Napi::TypeError::New(env, "BLST_ERROR: msgs must have length > 0")
+                Napi::TypeError::New(
+                    env, "BLST_ERROR: msgs must have length > 0")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;
             }
             if (msgs_array_length != pk_array_length) {
                 Napi::TypeError::New(
-                    env, "BLST_ERROR: msgs and publicKeys must be the same length")
+                    env,
+                    "BLST_ERROR: msgs and publicKeys must be the same length")
                     .ThrowAsJavaScriptException();
                 m_has_error = true;
                 return;

--- a/rebuild/src/functions.cc
+++ b/rebuild/src/functions.cc
@@ -257,9 +257,9 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
             }
             Napi::Object set = set_value.As<Napi::Object>();
 
-            Napi::Value msg_value = set.Get("msg");
+            Napi::Value msg_value = set.Get("message");
             BLST_TS_UNWRAP_UINT_8_ARRAY(
-                msg_value, msg, "msg", scope.Escape(env.Undefined()))
+                msg_value, msg, "message", scope.Escape(env.Undefined()))
 
             Napi::Value pk_val = set.Get("publicKey");
             PointerGroup<blst::P1_Affine> pk_ptr_group;
@@ -364,8 +364,8 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
                 }
                 Napi::Object set = set_value.As<Napi::Object>();
 
-                Napi::Value msg_value = set.Get("msg");
-                BLST_TS_UNWRAP_UINT_8_ARRAY(msg_value, msg, "msg", )
+                Napi::Value msg_value = set.Get("message");
+                BLST_TS_UNWRAP_UINT_8_ARRAY(msg_value, msg, "message", )
 
                 m_sets.push_back(
                     {PointerGroup<blst::P1_Affine>(),

--- a/rebuild/src/public_key.cc
+++ b/rebuild/src/public_key.cc
@@ -59,7 +59,8 @@ Napi::Value PublicKey::Deserialize(const Napi::CallbackInfo &info) {
     if (!info[1].IsUndefined()) {
         Napi::Value type_val = info[1].As<Napi::Value>();
         if (!type_val.IsNumber()) {
-            Napi::TypeError::New(env, "BLST_ERROR: type must be of enum CoordType (number)")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: type must be of enum CoordType (number)")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }

--- a/rebuild/src/secret_key.cc
+++ b/rebuild/src/secret_key.cc
@@ -154,7 +154,8 @@ Napi::Value SecretKey::Sign(const Napi::CallbackInfo &info) {
 
     // Check for zero key and throw error to meet spec requirements
     if (_is_zero_key) {
-        Napi::TypeError::New(env, "BLST_ERROR: cannot sign message with zero private key")
+        Napi::TypeError::New(
+            env, "BLST_ERROR: cannot sign message with zero private key")
             .ThrowAsJavaScriptException();
         return scope.Escape(info.Env().Undefined());
     }

--- a/rebuild/src/signature.cc
+++ b/rebuild/src/signature.cc
@@ -59,7 +59,8 @@ Napi::Value Signature::Deserialize(const Napi::CallbackInfo &info) {
     if (!info[1].IsUndefined()) {
         Napi::Value type_val = info[1].As<Napi::Value>();
         if (!type_val.IsNumber()) {
-            Napi::TypeError::New(env, "BLST_ERROR: type must be of enum CoordType (number)")
+            Napi::TypeError::New(
+                env, "BLST_ERROR: type must be of enum CoordType (number)")
                 .ThrowAsJavaScriptException();
             return scope.Escape(env.Undefined());
         }

--- a/rebuild/test/__fixtures__/index.ts
+++ b/rebuild/test/__fixtures__/index.ts
@@ -1,4 +1,4 @@
-import {fromHex, getFilledUint8, makeNapiTestSet, makeNapiTestSets, sullyUint8Array} from "../utils";
+import {fromHex, getFilledUint8, makeNapiTestSet, makeNapiTestSets, sullyUint8Array} from "../utils.js";
 
 export const invalidInputs: [string, any][] = [
   ["boolean", true],

--- a/rebuild/test/__fixtures__/index.ts
+++ b/rebuild/test/__fixtures__/index.ts
@@ -61,9 +61,9 @@ export const validSignature = {
 export const badSignature = sullyUint8Array(makeNapiTestSet().signature.serialize(false));
 
 export const validSignatureSet = makeNapiTestSets(1).map((set) => {
-  const {msg, secretKey, publicKey, signature} = set;
+  const {message, secretKey, publicKey, signature} = set;
   return {
-    msg,
+    message,
     secretKey,
     publicKey,
     signature,

--- a/rebuild/test/spec/downloadTests.ts
+++ b/rebuild/test/spec/downloadTests.ts
@@ -4,8 +4,12 @@ import path from "node:path";
 import {execSync} from "node:child_process";
 import tar from "tar";
 import fetch from "node-fetch";
-import {SPEC_TEST_LOCATION, SPEC_TEST_VERSION, SPEC_TEST_REPO_URL, SPEC_TEST_TO_DOWNLOAD} from "./specTestVersioning";
-
+import {
+  SPEC_TEST_LOCATION,
+  SPEC_TEST_VERSION,
+  SPEC_TEST_REPO_URL,
+  SPEC_TEST_TO_DOWNLOAD,
+} from "./specTestVersioning.js";
 
 const specVersion = SPEC_TEST_VERSION;
 const outputDir = SPEC_TEST_LOCATION;

--- a/rebuild/test/spec/specTestVersioning.ts
+++ b/rebuild/test/spec/specTestVersioning.ts
@@ -1,4 +1,7 @@
-import path from "path";
+import {join, dirname} from "path";
+import {fileURLToPath} from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // WARNING! Don't move or rename this file !!!
 //
@@ -11,4 +14,4 @@ export const SPEC_TEST_REPO_URL = "https://github.com/ethereum/consensus-spec-te
 export const SPEC_TEST_VERSION = "v1.3.0";
 export const SPEC_TEST_TO_DOWNLOAD = ["general" as const];
 // Target directory is the host package root: '<roo>/spec-tests'
-export const SPEC_TEST_LOCATION = path.join(__dirname, "../../spec-tests");
+export const SPEC_TEST_LOCATION = join(__dirname, "../../spec-tests");

--- a/rebuild/test/types.ts
+++ b/rebuild/test/types.ts
@@ -1,4 +1,4 @@
-import * as bindings from "../lib";
+import * as bindings from "../lib/index.js";
 
 export type BufferLike = string | bindings.BlstBuffer;
 

--- a/rebuild/test/types.ts
+++ b/rebuild/test/types.ts
@@ -3,7 +3,7 @@ import * as bindings from "../lib";
 export type BufferLike = string | bindings.BlstBuffer;
 
 export interface NapiTestSet {
-  msg: Uint8Array;
+  message: Uint8Array;
   secretKey: bindings.SecretKey;
   publicKey: bindings.PublicKey;
   signature: bindings.Signature;

--- a/rebuild/test/unit/PublicKey.test.ts
+++ b/rebuild/test/unit/PublicKey.test.ts
@@ -1,7 +1,13 @@
 import {expect} from "chai";
-import {BLST_CONSTANTS, CoordType, PublicKey, SecretKey} from "../../lib";
-import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils";
-import {validPublicKey, SECRET_KEY_BYTES, invalidInputs, badPublicKey, G1_POINT_AT_INFINITY} from "../__fixtures__";
+import {BLST_CONSTANTS, CoordType, PublicKey, SecretKey} from "../../lib/index.js";
+import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils.js";
+import {
+  validPublicKey,
+  SECRET_KEY_BYTES,
+  invalidInputs,
+  badPublicKey,
+  G1_POINT_AT_INFINITY,
+} from "../__fixtures__/index.js";
 
 describe("PublicKey", () => {
   it("should exist", () => {

--- a/rebuild/test/unit/SecretKey.test.ts
+++ b/rebuild/test/unit/SecretKey.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {PublicKey, SecretKey, Signature, BLST_CONSTANTS} from "../../lib";
-import {KEY_MATERIAL, SECRET_KEY_BYTES, invalidInputs} from "../__fixtures__";
-import {expectEqualHex, expectNotEqualHex} from "../utils";
+import {PublicKey, SecretKey, Signature, BLST_CONSTANTS} from "../../lib/index.js";
+import {KEY_MATERIAL, SECRET_KEY_BYTES, invalidInputs} from "../__fixtures__/index.js";
+import {expectEqualHex, expectNotEqualHex} from "../utils.js";
 
 describe("SecretKey", () => {
   it("should exist", () => {

--- a/rebuild/test/unit/Signature.test.ts
+++ b/rebuild/test/unit/Signature.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {BLST_CONSTANTS, CoordType, SecretKey, Signature} from "../../lib";
-import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils";
-import {KEY_MATERIAL, invalidInputs, validSignature} from "../__fixtures__";
+import {BLST_CONSTANTS, CoordType, SecretKey, Signature} from "../../lib/index.js";
+import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils.js";
+import {KEY_MATERIAL, invalidInputs, validSignature} from "../__fixtures__/index.js";
 
 describe("Signature", () => {
   it("should exist", () => {

--- a/rebuild/test/unit/aggregatePublicKeys.test.ts
+++ b/rebuild/test/unit/aggregatePublicKeys.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {aggregatePublicKeys, PublicKey} from "../../lib";
-import {isEqualBytes, makeNapiTestSets} from "../utils";
-import {badPublicKey} from "../__fixtures__";
+import {aggregatePublicKeys, PublicKey} from "../../lib/index.js";
+import {isEqualBytes, makeNapiTestSets} from "../utils.js";
+import {badPublicKey} from "../__fixtures__/index.js";
 
 describe("Aggregate Public Keys", () => {
   const sets = makeNapiTestSets(10);

--- a/rebuild/test/unit/aggregateSignatures.test.ts
+++ b/rebuild/test/unit/aggregateSignatures.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
-import {aggregateSignatures, Signature} from "../../lib";
-import {isEqualBytes, makeNapiTestSets} from "../utils";
-import {badSignature} from "../__fixtures__";
+import {aggregateSignatures, Signature} from "../../lib/index.js";
+import {isEqualBytes, makeNapiTestSets} from "../utils.js";
+import {badSignature} from "../__fixtures__/index.js";
 
 describe("Aggregate Signatures", () => {
   const sets = makeNapiTestSets(10);

--- a/rebuild/test/unit/bindings.test.ts
+++ b/rebuild/test/unit/bindings.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import * as bindings from "../../lib";
+import * as bindings from "../../lib/index.js";
 
 describe("bindings", () => {
   describe("exports", () => {

--- a/rebuild/test/unit/verify.test.ts
+++ b/rebuild/test/unit/verify.test.ts
@@ -6,9 +6,9 @@ import {
   asyncVerify,
   fastAggregateVerify,
   verify,
-} from "../../lib";
-import {sullyUint8Array, makeNapiTestSets} from "../utils";
-import {NapiTestSet} from "../types";
+} from "../../lib/index.js";
+import {sullyUint8Array, makeNapiTestSets} from "../utils.js";
+import {NapiTestSet} from "../types.js";
 
 describe("Verify", () => {
   let testSet: NapiTestSet;
@@ -37,10 +37,10 @@ describe("Verify", () => {
     });
     it("should default to Promise<false>", async () => {
       expect(await asyncVerify(sullyUint8Array(testSet.message), testSet.publicKey, testSet.signature)).to.be.false;
-      expect(await asyncVerify(testSet.message, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be
-        .false;
-      expect(await asyncVerify(testSet.message, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be
-        .false;
+      expect(await asyncVerify(testSet.message, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to
+        .be.false;
+      expect(await asyncVerify(testSet.message, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to
+        .be.false;
     });
     it("should return true for valid sets", async () => {
       expect(await asyncVerify(testSet.message, testSet.publicKey, testSet.signature)).to.be.true;
@@ -59,10 +59,10 @@ describe("Aggregate Verify", () => {
     });
     it("should default to false", () => {
       expect(aggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to.be.false;
-      expect(aggregateVerify([testSet.message], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to.be
-        .false;
-      expect(aggregateVerify([testSet.message], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to.be
-        .false;
+      expect(aggregateVerify([testSet.message], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
+        .be.false;
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
+        .be.false;
     });
     it("should return true for valid sets", () => {
       expect(aggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.true;
@@ -76,13 +76,21 @@ describe("Aggregate Verify", () => {
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncAggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to.be
-        .false;
+      expect(await asyncAggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to
+        .be.false;
       expect(
-        await asyncAggregateVerify([testSet.message], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
+        await asyncAggregateVerify(
+          [testSet.message],
+          [sullyUint8Array(testSet.publicKey.serialize())],
+          testSet.signature
+        )
       ).to.be.false;
       expect(
-        await asyncAggregateVerify([testSet.message], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
+        await asyncAggregateVerify(
+          [testSet.message],
+          [testSet.publicKey],
+          sullyUint8Array(testSet.signature.serialize())
+        )
       ).to.be.false;
     });
     it("should return true for valid sets", async () => {
@@ -102,10 +110,10 @@ describe("Fast Aggregate Verify", () => {
     });
     it("should default to false", () => {
       expect(fastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature)).to.be.false;
-      expect(fastAggregateVerify(testSet.message, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
-        .be.false;
-      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
-        .be.false;
+      expect(fastAggregateVerify(testSet.message, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature))
+        .to.be.false;
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize())))
+        .to.be.false;
     });
     it("should return true for valid sets", () => {
       expect(fastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.true;
@@ -119,13 +127,21 @@ describe("Fast Aggregate Verify", () => {
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncFastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature)).to.be
-        .false;
+      expect(await asyncFastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature))
+        .to.be.false;
       expect(
-        await asyncFastAggregateVerify(testSet.message, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
+        await asyncFastAggregateVerify(
+          testSet.message,
+          [sullyUint8Array(testSet.publicKey.serialize())],
+          testSet.signature
+        )
       ).to.be.false;
       expect(
-        await asyncFastAggregateVerify(testSet.message, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
+        await asyncFastAggregateVerify(
+          testSet.message,
+          [testSet.publicKey],
+          sullyUint8Array(testSet.signature.serialize())
+        )
       ).to.be.false;
     });
     it("should return true for valid sets", async () => {

--- a/rebuild/test/unit/verify.test.ts
+++ b/rebuild/test/unit/verify.test.ts
@@ -17,33 +17,33 @@ describe("Verify", () => {
   });
   describe("verify", () => {
     it("should return a boolean", () => {
-      expect(verify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.a("boolean");
+      expect(verify(testSet.message, testSet.publicKey, testSet.signature)).to.be.a("boolean");
     });
     it("should default to false", () => {
-      expect(verify(sullyUint8Array(testSet.msg), testSet.publicKey, testSet.signature)).to.be.false;
-      expect(verify(testSet.msg, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be.false;
-      expect(verify(testSet.msg, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be.false;
+      expect(verify(sullyUint8Array(testSet.message), testSet.publicKey, testSet.signature)).to.be.false;
+      expect(verify(testSet.message, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be.false;
+      expect(verify(testSet.message, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be.false;
     });
     it("should return true for valid sets", () => {
-      expect(verify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+      expect(verify(testSet.message, testSet.publicKey, testSet.signature)).to.be.true;
     });
   });
   describe("asyncVerify", () => {
     it("should return Promise<boolean>", async () => {
-      const resPromise = asyncVerify(testSet.msg, testSet.publicKey, testSet.signature);
+      const resPromise = asyncVerify(testSet.message, testSet.publicKey, testSet.signature);
       expect(resPromise).to.be.instanceOf(Promise);
       const res = await resPromise;
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncVerify(sullyUint8Array(testSet.msg), testSet.publicKey, testSet.signature)).to.be.false;
-      expect(await asyncVerify(testSet.msg, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be
+      expect(await asyncVerify(sullyUint8Array(testSet.message), testSet.publicKey, testSet.signature)).to.be.false;
+      expect(await asyncVerify(testSet.message, sullyUint8Array(testSet.publicKey.serialize()), testSet.signature)).to.be
         .false;
-      expect(await asyncVerify(testSet.msg, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be
+      expect(await asyncVerify(testSet.message, testSet.publicKey, sullyUint8Array(testSet.signature.serialize()))).to.be
         .false;
     });
     it("should return true for valid sets", async () => {
-      expect(await asyncVerify(testSet.msg, testSet.publicKey, testSet.signature)).to.be.true;
+      expect(await asyncVerify(testSet.message, testSet.publicKey, testSet.signature)).to.be.true;
     });
   });
 });
@@ -55,38 +55,38 @@ describe("Aggregate Verify", () => {
   });
   describe("aggregateVerify", () => {
     it("should return a boolean", () => {
-      expect(aggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.a("boolean");
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.a("boolean");
     });
     it("should default to false", () => {
-      expect(aggregateVerify([sullyUint8Array(testSet.msg)], [testSet.publicKey], testSet.signature)).to.be.false;
-      expect(aggregateVerify([testSet.msg], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to.be
+      expect(aggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to.be.false;
+      expect(aggregateVerify([testSet.message], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to.be
         .false;
-      expect(aggregateVerify([testSet.msg], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to.be
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to.be
         .false;
     });
     it("should return true for valid sets", () => {
-      expect(aggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(aggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
   describe("asyncAggregateVerify", () => {
     it("should return Promise<boolean>", async () => {
-      const resPromise = asyncAggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature);
+      const resPromise = asyncAggregateVerify([testSet.message], [testSet.publicKey], testSet.signature);
       expect(resPromise).to.be.instanceOf(Promise);
       const res = await resPromise;
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncAggregateVerify([sullyUint8Array(testSet.msg)], [testSet.publicKey], testSet.signature)).to.be
+      expect(await asyncAggregateVerify([sullyUint8Array(testSet.message)], [testSet.publicKey], testSet.signature)).to.be
         .false;
       expect(
-        await asyncAggregateVerify([testSet.msg], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
+        await asyncAggregateVerify([testSet.message], [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
       ).to.be.false;
       expect(
-        await asyncAggregateVerify([testSet.msg], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
+        await asyncAggregateVerify([testSet.message], [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
       ).to.be.false;
     });
     it("should return true for valid sets", async () => {
-      expect(await asyncAggregateVerify([testSet.msg], [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(await asyncAggregateVerify([testSet.message], [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
 });
@@ -98,38 +98,38 @@ describe("Fast Aggregate Verify", () => {
   });
   describe("fastAggregateVerify", () => {
     it("should return a boolean", () => {
-      expect(fastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature)).to.be.a("boolean");
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.a("boolean");
     });
     it("should default to false", () => {
-      expect(fastAggregateVerify(sullyUint8Array(testSet.msg), [testSet.publicKey], testSet.signature)).to.be.false;
-      expect(fastAggregateVerify(testSet.msg, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
+      expect(fastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature)).to.be.false;
+      expect(fastAggregateVerify(testSet.message, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)).to
         .be.false;
-      expect(fastAggregateVerify(testSet.msg, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))).to
         .be.false;
     });
     it("should return true for valid sets", () => {
-      expect(fastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(fastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
   describe("asyncFastAggregateVerify", () => {
     it("should return Promise<boolean>", async () => {
-      const resPromise = asyncFastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature);
+      const resPromise = asyncFastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature);
       expect(resPromise).to.be.instanceOf(Promise);
       const res = await resPromise;
       expect(res).to.be.a("boolean");
     });
     it("should default to Promise<false>", async () => {
-      expect(await asyncFastAggregateVerify(sullyUint8Array(testSet.msg), [testSet.publicKey], testSet.signature)).to.be
+      expect(await asyncFastAggregateVerify(sullyUint8Array(testSet.message), [testSet.publicKey], testSet.signature)).to.be
         .false;
       expect(
-        await asyncFastAggregateVerify(testSet.msg, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
+        await asyncFastAggregateVerify(testSet.message, [sullyUint8Array(testSet.publicKey.serialize())], testSet.signature)
       ).to.be.false;
       expect(
-        await asyncFastAggregateVerify(testSet.msg, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
+        await asyncFastAggregateVerify(testSet.message, [testSet.publicKey], sullyUint8Array(testSet.signature.serialize()))
       ).to.be.false;
     });
     it("should return true for valid sets", async () => {
-      expect(await asyncFastAggregateVerify(testSet.msg, [testSet.publicKey], testSet.signature)).to.be.true;
+      expect(await asyncFastAggregateVerify(testSet.message, [testSet.publicKey], testSet.signature)).to.be.true;
     });
   });
 });

--- a/rebuild/test/unit/verifyMultipleAggregateSignatures.test.ts
+++ b/rebuild/test/unit/verifyMultipleAggregateSignatures.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
-import {asyncVerifyMultipleAggregateSignatures, verifyMultipleAggregateSignatures} from "../../lib";
-import {makeNapiTestSets} from "../utils";
+import {asyncVerifyMultipleAggregateSignatures, verifyMultipleAggregateSignatures} from "../../lib/index.js";
+import {makeNapiTestSets} from "../utils.js";
 
 describe("Verify Multiple Aggregate Signatures", () => {
   describe("verifyMultipleAggregateSignatures", () => {

--- a/rebuild/test/utils.ts
+++ b/rebuild/test/utils.ts
@@ -45,22 +45,22 @@ export function sullyUint8Array(bytes: Uint8Array): Uint8Array {
 
 const DEFAULT_TEST_MESSAGE = Uint8Array.from(Buffer.from("test-message"));
 
-export function makeNapiTestSet(msg: Uint8Array = DEFAULT_TEST_MESSAGE): NapiTestSet {
+export function makeNapiTestSet(message: Uint8Array = DEFAULT_TEST_MESSAGE): NapiTestSet {
   const secretKey = bindings.SecretKey.fromKeygen(randomFillSync(Buffer.alloc(32)));
   const publicKey = secretKey.toPublicKey();
-  const signature = secretKey.sign(msg);
+  const signature = secretKey.sign(message);
   return {
-    msg,
+    message,
     secretKey,
     publicKey,
     signature,
   };
 }
 
-export function makeNapiTestSets(numSets: number, msg = DEFAULT_TEST_MESSAGE): NapiTestSet[] {
+export function makeNapiTestSets(numSets: number, message = DEFAULT_TEST_MESSAGE): NapiTestSet[] {
   const sets: NapiTestSet[] = [];
   for (let i = 0; i < numSets; i++) {
-    sets.push(makeNapiTestSet(msg));
+    sets.push(makeNapiTestSet(message));
   }
   return sets;
 }

--- a/rebuild/test/utils.ts
+++ b/rebuild/test/utils.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {randomFillSync} from "crypto";
-import * as bindings from "../lib";
-import {BufferLike, NapiTestSet} from "./types";
+import * as bindings from "../lib/index.js";
+import {BufferLike, NapiTestSet} from "./types.js";
 
 function toHexString(bytes: BufferLike): string {
   if (typeof bytes === "string") return bytes;

--- a/rebuild/tsconfig.json
+++ b/rebuild/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["lib/", "test/", "tools/"],
+  "include": ["lib", "test", "tools"],
   "compilerOptions": {
     "noEmit": true,
     "target": "esnext",

--- a/rebuild/tsconfig.json
+++ b/rebuild/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "include": ["lib", "test", "tools"],
+  "include": ["lib/", "test/", "tools/"],
   "compilerOptions": {
     "noEmit": true,
     "target": "esnext",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "NodeNext",
     "lib": ["ESNext"],
 
     "strict": true,


### PR DESCRIPTION


## Inclusions
- Add `toHex` method to `SecretKey`, `PublicKey` and `Signature`
- Convert to esmodule
- Add `default` export
- Rename msg->message in SignatureSet
- Lint files