### PR TITLE
feat: add MultiplyBy

### DIFF
--- a/rebuild/lib/index.d.ts
+++ b/rebuild/lib/index.d.ts
@@ -83,6 +83,7 @@ export class PublicKey implements Serializable {
   toHex(compress?: boolean): string;
   keyValidate(): void;
   isInfinity(): boolean;
+  multiplyBy(randomBytes: BlstBuffer): PublicKey;
 }
 
 export class Signature implements Serializable {
@@ -92,6 +93,7 @@ export class Signature implements Serializable {
   toHex(compress?: boolean): string;
   sigValidate(): void;
   isInfinity(): boolean;
+  multiplyBy(randomBytes: BlstBuffer): Signature;
 }
 
 /**

--- a/rebuild/src/public_key.cc
+++ b/rebuild/src/public_key.cc
@@ -21,6 +21,10 @@ void PublicKey::Init(
             "isInfinity",
             &PublicKey::IsInfinity,
             static_cast<napi_property_attributes>(napi_enumerable)),
+        InstanceMethod(
+            "multiplyBy",
+            &PublicKey::MultiplyBy,
+            static_cast<napi_property_attributes>(napi_enumerable)),
     };
 
     Napi::Function ctr = DefineClass(env, "PublicKey", proto, module);
@@ -130,6 +134,21 @@ Napi::Value PublicKey::KeyValidate(const Napi::CallbackInfo &info) {
     return info.Env().Undefined();
 }
 
-Napi::Value PublicKey::IsInfinity(const Napi::CallbackInfo &info) {
-    BLST_TS_IS_INFINITY
+Napi::Value PublicKey::IsInfinity(const Napi::CallbackInfo &info){
+    BLST_TS_IS_INFINITY}
+
+Napi::Value PublicKey::MultiplyBy(const Napi::CallbackInfo &info) {
+    BLST_TS_FUNCTION_PREAMBLE(info, env, module)
+    Napi::Value rand_bytes_value = info[0];
+    BLST_TS_UNWRAP_UINT_8_ARRAY(rand_bytes_value, rand_bytes, "randomBytes")
+
+    Napi::Object pk_obj = module->_public_key_ctr.New(
+        // Default to jacobian coordinates
+        {Napi::External<P1Wrapper>::New(
+             env,
+             new P1{_point->MultiplyBy(
+                 rand_bytes.Data(), rand_bytes.ByteLength())}),
+         Napi::Boolean::New(env, false)});
+
+    return scope.Escape(pk_obj);
 }

--- a/rebuild/src/signature.cc
+++ b/rebuild/src/signature.cc
@@ -22,6 +22,10 @@ void Signature::Init(
             "isInfinity",
             &Signature::IsInfinity,
             static_cast<napi_property_attributes>(napi_enumerable)),
+        InstanceMethod(
+            "multiplyBy",
+            &Signature::MultiplyBy,
+            static_cast<napi_property_attributes>(napi_enumerable)),
     };
 
     Napi::Function ctr = DefineClass(env, "Signature", proto, module);
@@ -127,6 +131,21 @@ Napi::Value Signature::SigValidate(const Napi::CallbackInfo &info) {
     return env.Undefined();
 }
 
-Napi::Value Signature::IsInfinity(const Napi::CallbackInfo &info) {
-    BLST_TS_IS_INFINITY
+Napi::Value Signature::IsInfinity(const Napi::CallbackInfo &info){
+    BLST_TS_IS_INFINITY}
+
+Napi::Value Signature::MultiplyBy(const Napi::CallbackInfo &info) {
+    BLST_TS_FUNCTION_PREAMBLE(info, env, module)
+    Napi::Value rand_bytes_value = info[0];
+    BLST_TS_UNWRAP_UINT_8_ARRAY(rand_bytes_value, rand_bytes, "randomBytes")
+
+    Napi::Object sig_obj = module->_signature_ctr.New(
+        // Default to jacobian coordinates
+        {Napi::External<P2Wrapper>::New(
+             env,
+             new P2{_point->MultiplyBy(
+                 rand_bytes.Data(), rand_bytes.ByteLength())}),
+         Napi::Boolean::New(env, false)});
+
+    return scope.Escape(sig_obj);
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -300,7 +300,7 @@ export function verifyMultipleAggregateSignatures(signatureSets: SignatureSet[])
  * `rand` must not be exactly zero. Otherwise it would allow the verification of invalid signatures
  * See https://github.com/ChainSafe/blst-ts/issues/45
  */
-function randomBytesNonZero(BYTES_COUNT: number): Buffer {
+export function randomBytesNonZero(BYTES_COUNT: number): Buffer {
   const rand = crypto.randomBytes(BYTES_COUNT);
   for (let i = 0; i < BYTES_COUNT; i++) {
     if (rand[0] !== 0) return rand;

--- a/test/utils/multithreading/blsMultiThreading.ts
+++ b/test/utils/multithreading/blsMultiThreading.ts
@@ -46,6 +46,7 @@ const MAX_JOBS_CAN_ACCEPT_WORK = 512;
 export class BlsMultiThreading {
   readonly blsPoolSize: number;
 
+  private readonly addVerificationRandomness: boolean;
   private readonly blsVerifyAllInQueue: boolean;
   private readonly blsPoolType: BlsPoolType;
   private readonly workers: WorkerDescriptor[] = [];
@@ -63,6 +64,7 @@ export class BlsMultiThreading {
   private workersBusy = 0;
 
   constructor(options: BlsMultiThreadWorkerPoolOptions /*, modules: BlsMultiThreadWorkerPoolModules */) {
+    this.addVerificationRandomness = options.addVerificationRandomness ?? false;
     this.blsVerifyAllInQueue = options.blsVerifyAllInQueue ?? false;
     this.blsPoolType = options.blsPoolType ?? BlsPoolType.workers;
 
@@ -122,7 +124,7 @@ export class BlsMultiThreading {
               resolve,
               reject,
               addedTimeMs: Date.now(),
-              opts,
+              opts: {...opts, addVerificationRandomness: this.addVerificationRandomness},
               sets: setsChunk,
               message,
             });

--- a/test/utils/multithreading/types.ts
+++ b/test/utils/multithreading/types.ts
@@ -81,6 +81,7 @@ export enum BlsPoolType {
 export type BlsMultiThreadWorkerPoolOptions = {
   blsVerifyAllInQueue?: boolean;
   blsPoolType?: BlsPoolType;
+  addVerificationRandomness?: boolean;
 };
 
 export type BlsMultiThreadWorkerPoolModules = Record<string, never>;
@@ -89,6 +90,7 @@ export interface VerifySignatureOpts {
   batchable?: boolean;
   verifyOnMainThread?: boolean;
   priority?: boolean;
+  addVerificationRandomness?: boolean;
 }
 
 export interface SerializedSwigSet {


### PR DESCRIPTION


Perf Results
```sh
  multithreading perf - addVerificationRandomness true
    ✓ libuv multithreading - napi - addVerificationRandomness true       0.2730140 ops/s    3.662816  s/op        -         12 runs   47.7 s
    ✓ worker multithreading - swig - addVerificationRandomness true      0.2128583 ops/s    4.697962  s/op        -         12 runs   61.0 s
{ libuvPoolSize: 9, workerPoolSize: 9 }

  multithreading perf - addVerificationRandomness false
    ✓ libuv multithreading - napi - addVerificationRandomness false      0.2842713 ops/s    3.517767  s/op        -         12 runs   45.7 s
    ✓ worker multithreading - swig - addVerificationRandomness false     0.2274196 ops/s    4.397158  s/op        -         12 runs   57.2 s
{ libuvPoolSize: 9, workerPoolSize: 9 }
```