### PR TITLE
feat: make serialized objects Uint8Array instead of Buffer

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -96,7 +96,7 @@ export class SecretKey implements Serializable {
   /**
    * Serialize a secret key into a Buffer.
    */
-  serialize(): Buffer;
+  serialize(): Uint8Array;
   toHex(): string;
   toPublicKey(): PublicKey;
   sign(msg: BlstBuffer): Signature;
@@ -108,7 +108,7 @@ export class PublicKey implements Serializable {
    * Convert a serialized public key into a PublicKey object.
    */
   static deserialize(pkBytes: BlstBuffer, coordType?: CoordType): PublicKey;
-  serialize(compress?: boolean): Buffer;
+  serialize(compress?: boolean): Uint8Array;
   toHex(compress?: boolean): string;
   keyValidate(): void;
   isInfinity(): boolean;
@@ -121,7 +121,7 @@ export class Signature implements Serializable {
    * Convert a serialized signature into a Signature object.
    */
   static deserialize(sigBytes: BlstBuffer, coordType?: CoordType): Signature;
-  serialize(compress?: boolean): Buffer;
+  serialize(compress?: boolean): Uint8Array;
   toHex(compress?: boolean): string;
   sigValidate(): void;
   isInfinity(): boolean;

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,17 +23,25 @@ const rootDir = __dirname.endsWith("dist/lib")
     : resolve(__dirname, "..");
 const bindingsPath = getBindingsPath(rootDir);
 
+function convertToHex(array) {
+  // padd with leading 0 if <16
+  function i2hex(i) {
+    return ("0" + i.toString(16)).slice(-2);
+  }
+  return array.reduce((ret, i) => ret + i2hex(i), "");
+}
+
 function prepareBindings(bindings) {
   bindings.SecretKey.prototype.toHex = function toHex() {
-    return `0x${this.serialize().toString("hex")}`;
+    return `0x${convertToHex(this.serialize())}`;
   };
 
   bindings.PublicKey.prototype.toHex = function toHex(compress) {
-    return `0x${this.serialize(compress).toString("hex")}`;
+    return `0x${convertToHex(this.serialize(compress))}`;
   };
 
   bindings.Signature.prototype.toHex = function toHex(compress) {
-    return `0x${this.serialize(compress).toString("hex")}`;
+    return `0x${convertToHex(this.serialize(compress))}`;
   };
 
   return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,25 +23,17 @@ const rootDir = __dirname.endsWith("dist/lib")
     : resolve(__dirname, "..");
 const bindingsPath = getBindingsPath(rootDir);
 
-function convertToHex(array) {
-  // padd with leading 0 if <16
-  function i2hex(i) {
-    return ("0" + i.toString(16)).slice(-2);
-  }
-  return array.reduce((ret, i) => ret + i2hex(i), "");
-}
-
 function prepareBindings(bindings) {
   bindings.SecretKey.prototype.toHex = function toHex() {
-    return `0x${convertToHex(this.serialize())}`;
+    return `0x${Buffer.from(this.serialize().buffer).toString("hex")}`;
   };
 
   bindings.PublicKey.prototype.toHex = function toHex(compress) {
-    return `0x${convertToHex(this.serialize(compress))}`;
+    return `0x${Buffer.from(this.serialize(compress).buffer).toString("hex")}`;
   };
 
   bindings.Signature.prototype.toHex = function toHex(compress) {
-    return `0x${convertToHex(this.serialize(compress))}`;
+    return `0x${Buffer.from(this.serialize(compress).buffer).toString("hex")}`;
   };
 
   return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,15 +25,18 @@ const bindingsPath = getBindingsPath(rootDir);
 
 function prepareBindings(bindings) {
   bindings.SecretKey.prototype.toHex = function toHex() {
-    return `0x${Buffer.from(this.serialize().buffer).toString("hex")}`;
+    const uint8 = this.serialize();
+    return `0x${Buffer.from(uint8.buffer, uint8.byteOffset, uint8.byteLength).toString("hex")}`;
   };
 
   bindings.PublicKey.prototype.toHex = function toHex(compress) {
-    return `0x${Buffer.from(this.serialize(compress).buffer).toString("hex")}`;
+    const uint8 = this.serialize(compress);
+    return `0x${Buffer.from(uint8.buffer, uint8.byteOffset, uint8.byteLength).toString("hex")}`;
   };
 
   bindings.Signature.prototype.toHex = function toHex(compress) {
-    return `0x${Buffer.from(this.serialize(compress).buffer).toString("hex")}`;
+    const uint8 = this.serialize(compress);
+    return `0x${Buffer.from(uint8.buffer, uint8.byteOffset, uint8.byteLength).toString("hex")}`;
   };
 
   return {

--- a/src/addon.h
+++ b/src/addon.h
@@ -27,7 +27,7 @@ namespace blst_ts {
     if (!info[0].IsUndefined()) {                                              \
         compressed = info[0].ToBoolean().Value();                              \
     }                                                                          \
-    Napi::Buffer<uint8_t> serialized = Napi::Buffer<uint8_t>::New(             \
+    Napi::Uint8Array serialized = Napi::Uint8Array::New(             \
         env,                                                                   \
         compressed ? snake_case_name##_length_compressed                       \
                    : snake_case_name##_length_uncompressed);                   \

--- a/src/secret_key.cc
+++ b/src/secret_key.cc
@@ -140,8 +140,8 @@ Napi::Value SecretKey::Serialize(const Napi::CallbackInfo &info) {
     Napi::Env env = info.Env();
     Napi::EscapableHandleScope scope(env);
 
-    Napi::Buffer<uint8_t> serialized =
-        Napi::Buffer<uint8_t>::New(env, secret_key_length);
+    Napi::Uint8Array serialized =
+        Napi::Uint8Array::New(env, secret_key_length);
     key->to_bendian(serialized.Data());
 
     return scope.Escape(serialized);

--- a/test/unit/PublicKey.test.ts
+++ b/test/unit/PublicKey.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {BLST_CONSTANTS, CoordType, PublicKey, SecretKey} from "../../lib";
 import {expectEqualHex, expectNotEqualHex, sullyUint8Array} from "../utils";
-import {validPublicKey, SECRET_KEY_BYTES, invalidInputs, badPublicKey, G1_POINT_AT_INFINITY} from "../__fixtures__";
+import {validPublicKey, SECRET_KEY_BYTES, invalidInputs, G1_POINT_AT_INFINITY} from "../__fixtures__";
 
 describe("PublicKey", () => {
   it("should exist", () => {
@@ -86,6 +86,12 @@ describe("PublicKey", () => {
         const affine = PublicKey.deserialize(pk.serialize(), CoordType.affine);
         expectEqualHex(jacobian.serialize(true), affine.serialize(true));
         expectEqualHex(jacobian.serialize(false), affine.serialize(false));
+      });
+    });
+    describe("toHex", () => {
+      it("should toHex string correctly", () => {
+        const key = PublicKey.deserialize(validPublicKey.compressed);
+        expectEqualHex(key.toHex(true), validPublicKey.compressed);
       });
     });
     describe("keyValidate()", () => {

--- a/test/unit/PublicKey.test.ts
+++ b/test/unit/PublicKey.test.ts
@@ -71,6 +71,9 @@ describe("PublicKey", () => {
     describe("serialize", () => {
       const sk = SecretKey.deserialize(SECRET_KEY_BYTES);
       const pk = sk.toPublicKey();
+      it("should serialize the key to Uint8Array", () => {
+        expect(pk.serialize()).to.be.instanceof(Uint8Array);
+      });
       it("should default to compressed serialization", () => {
         expectEqualHex(pk.serialize(), pk.serialize(true));
         expectNotEqualHex(pk.serialize(), pk.serialize(false));

--- a/test/unit/SecretKey.test.ts
+++ b/test/unit/SecretKey.test.ts
@@ -70,7 +70,7 @@ describe("SecretKey", () => {
     });
     describe("serialize", () => {
       it("should serialize the key to Uint8Array", () => {
-        expect(key.serialize()).to.be.instanceof(Buffer);
+        expect(key.serialize()).to.be.instanceof(Uint8Array);
       });
       it("should be the correct length", () => {
         expect(key.serialize().length).to.equal(BLST_CONSTANTS.SECRET_KEY_LENGTH);

--- a/test/unit/SecretKey.test.ts
+++ b/test/unit/SecretKey.test.ts
@@ -80,6 +80,12 @@ describe("SecretKey", () => {
         expectEqualHex(SecretKey.deserialize(serialized).serialize(), serialized);
       });
     });
+    describe("toHex", () => {
+      it("should toHex string correctly", () => {
+        const key = SecretKey.deserialize(SECRET_KEY_BYTES);
+        expectEqualHex(key.toHex(), SECRET_KEY_BYTES);
+      });
+    });
     describe("toPublicKey", () => {
       it("should create a valid PublicKey", () => {
         const pk = key.toPublicKey();

--- a/test/unit/Signature.test.ts
+++ b/test/unit/Signature.test.ts
@@ -52,6 +52,9 @@ describe("Signature", () => {
   describe("methods", () => {
     describe("serialize", () => {
       const sig = SecretKey.fromKeygen(KEY_MATERIAL).sign(Buffer.from("some fancy message"));
+      it("should serialize the signature to Uint8Array", () => {
+        expect(sig.serialize()).to.be.instanceof(Uint8Array);
+      });
       it("should default to compressed serialization", () => {
         expectEqualHex(sig.serialize(), sig.serialize(true));
         expectNotEqualHex(sig.serialize(), sig.serialize(false));

--- a/test/unit/Signature.test.ts
+++ b/test/unit/Signature.test.ts
@@ -69,6 +69,12 @@ describe("Signature", () => {
         expectEqualHex(jacobian.serialize(false), affine.serialize(false));
       });
     });
+    describe("toHex", () => {
+      it("should toHex string correctly", () => {
+        const key = Signature.deserialize(validSignature.compressed);
+        expectEqualHex(key.toHex(true), validSignature.compressed);
+      });
+    });
     describe("sigValidate()", () => {
       it("should return undefined for valid", () => {
         const sig = Signature.deserialize(validSignature.compressed);


### PR DESCRIPTION
@nflaig pointed out that the return types are buffer not uint8array.  Putting this up in case we should move to uint8array.

After this and the `bls` package are published remove this cast in lodestar tests
https://github.com/ChainSafe/lodestar/pull/6616#discussion_r1567948604