### PR TITLE
feat: make sure random bytes are non-zero

### DIFF
--- a/src/addon.cc
+++ b/src/addon.cc
@@ -89,7 +89,7 @@ bool BlstTsAddon::GetRandomNonZeroBytes(blst::byte *bytes, size_t length) {
     do {
         if ((1 == RAND_status()) && (1 == RAND_bytes(bytes, length))) {
             if (blst_ts::is_zero_bytes(bytes, 0, length)) {
-                bytes[0] = 0xff;
+                bytes[0] = 0x01;
             }
             return true;
         }

--- a/src/addon.h
+++ b/src/addon.h
@@ -177,7 +177,7 @@ class BlstTsAddon : public Napi::Addon<BlstTsAddon> {
      * MUST check the return value for success!
      *
      * As a special case, |length == 0| can be used to check if the
-     * GetRandomBytes is properly seeded without consuming entropy.
+     * GetRandomNonZeroBytes is properly seeded without consuming entropy.
      */
-    bool GetRandomBytes(blst::byte *ikm, size_t length);
+    bool GetRandomNonZeroBytes(blst::byte *bytes, size_t length);
 };

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -490,7 +490,7 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
 
         for (uint32_t i = 0; i < sets_array_length; i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
-            if (!module->GetRandomBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
+            if (!module->GetRandomNonZeroBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
                 Napi::Error::New(
                     env, "BLST_ERROR: Failed to generate random bytes")
                     .ThrowAsJavaScriptException();
@@ -721,7 +721,7 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
     void Execute() {
         for (uint32_t i = 0; i < _sets.size(); i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
-            if (!_module->GetRandomBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
+            if (!_module->GetRandomNonZeroBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
                 SetError("BLST_ERROR: Failed to generate random bytes");
                 return;
             }


### PR DESCRIPTION
Caught an issue with verification

Ensure rand bytes are never all 0.

Was originally like this in the old blst
https://github.com/ChainSafe/blst-ts/blob/b1ba6333f664b08e5c50b2b0d18c4f079203962b/src/lib.ts#L288