### PR TITLE
fix: small issues post merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postbuild:ts": "ts-node scripts/prepareDist",
     "build:fuzz": "tsc --project tsconfig.fuzz.json",
     "build:clean": "npm run clean && npm run install && npm run build:ts",
-    "dev": "ts-node tools/dev",
+    "dev": "ts-node scripts/dev",
     "lint": "npm run lint:c && npm run lint:ts",
     "lint:c": "clang-format -i ./src/*",
     "lint:ts": "eslint --color --ext .js,.mjs,.cjs,.ts lib/ scripts/ test/ utils/",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:clean": "npm run clean && npm run install && npm run build:ts",
     "dev": "ts-node scripts/dev",
     "lint": "npm run lint:c && npm run lint:ts",
-    "lint:c": "clang-format -i ./src/*",
+    "lint:c": "clang-format -i src/*.cc src/*.h",
     "lint:ts": "eslint --color --ext .js,.mjs,.cjs,.ts lib/ scripts/ test/ utils/",
     "test": "yarn test:unit && yarn test:spec && yarn test:perf && yarn test:memory",
     "test:fuzz": "ts-node test/fuzz/fuzz.test.ts",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -6,14 +6,18 @@ import {exec} from "../utils";
 
 const DEBOUNCE_TIME = 500;
 const testCommand = "npm run test:unit && npm run test:spec";
-const buildCommand = "npm run build:debug";
+const buildCommand = "npm run build:gyp:debug";
 
 const ROOT_FOLDER = resolve(__dirname, "..");
 const SRC_FOLDER = resolve(ROOT_FOLDER, "src");
 const TESTS_FOLDER = resolve(ROOT_FOLDER, "test");
 
 // make sure code is using most recently built bindings
-fs.rmdirSync(resolve(ROOT_FOLDER, "prebuild"));
+try {
+  fs.rmdirSync(resolve(ROOT_FOLDER, "prebuild"));
+} catch {
+  /* no-op, doesn't exist */
+}
 
 /**
  * Builds addon and then starts watch.

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -76,33 +76,35 @@ async function buildBindings(binaryName: string): Promise<string> {
 
 async function install(): Promise<void> {
   const binaryName = getBinaryName();
-
-  // Check if bindings already bundled, downloaded or built
   let binaryPath: string | undefined = getPrebuiltBinaryPath(binaryName);
-  if (existsSync(binaryPath)) {
-    console.log(`Found prebuilt bindings at ${binaryPath}`);
-    try {
-      await testBindings(binaryPath);
-      return;
-    } catch {
-      console.log("Prebuilt and bundled bindings failed to load. Attempting to download.");
+
+  if (!(Boolean(process.env.CI) || Boolean(process.env.BLST_TS_FORCE_BUILD))) {
+    // Check if bindings already bundled, downloaded or built
+    if (existsSync(binaryPath)) {
+      console.log(`Found prebuilt bindings at ${binaryPath}`);
+      try {
+        await testBindings(binaryPath);
+        return;
+      } catch {
+        console.log("Prebuilt and bundled bindings failed to load. Attempting to download.");
+      }
     }
-  }
 
-  // Fetch pre-built bindings from remote repo
-  try {
-    binaryPath = await downloadBindings(binaryName);
-  } catch {
-    /* no-op */
-  }
-
-  if (existsSync(binaryPath)) {
-    console.log(`Downloaded github release bindings to ${binaryPath}`);
+    // Fetch pre-built bindings from remote repo
     try {
-      await testBindings(binaryPath);
-      return;
+      binaryPath = await downloadBindings(binaryName);
     } catch {
-      console.log("Downloaded bindings failed to load. Attempting to build.");
+      /* no-op */
+    }
+
+    if (existsSync(binaryPath)) {
+      console.log(`Downloaded github release bindings to ${binaryPath}`);
+      try {
+        await testBindings(binaryPath);
+        return;
+      } catch {
+        console.log("Downloaded bindings failed to load. Attempting to build.");
+      }
     }
   }
 

--- a/src/addon.h
+++ b/src/addon.h
@@ -12,6 +12,8 @@
 #include "blst.hpp"
 #include "napi.h"
 
+using namespace std::string_literals;
+
 namespace blst_ts {
 #define BLST_TS_RANDOM_BYTES_LENGTH 8U
 

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -1,7 +1,5 @@
 #include "addon.h"
 
-using namespace std::string_literals;
-
 namespace {
 Napi::Value AggregatePublicKeys(const Napi::CallbackInfo &info) {
     BLST_TS_FUNCTION_PREAMBLE(info, env, module)

--- a/src/functions.cc
+++ b/src/functions.cc
@@ -488,7 +488,8 @@ Napi::Value VerifyMultipleAggregateSignatures(const Napi::CallbackInfo &info) {
 
         for (uint32_t i = 0; i < sets_array_length; i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
-            if (!module->GetRandomNonZeroBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
+            if (!module->GetRandomNonZeroBytes(
+                    rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
                 Napi::Error::New(
                     env, "BLST_ERROR: Failed to generate random bytes")
                     .ThrowAsJavaScriptException();
@@ -719,7 +720,8 @@ class VerifyMultipleAggregateSignaturesWorker : public Napi::AsyncWorker {
     void Execute() {
         for (uint32_t i = 0; i < _sets.size(); i++) {
             blst::byte rand[BLST_TS_RANDOM_BYTES_LENGTH];
-            if (!_module->GetRandomNonZeroBytes(rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
+            if (!_module->GetRandomNonZeroBytes(
+                    rand, BLST_TS_RANDOM_BYTES_LENGTH)) {
                 SetError("BLST_ERROR: Failed to generate random bytes");
                 return;
             }

--- a/src/public_key.cc
+++ b/src/public_key.cc
@@ -1,7 +1,5 @@
 #include "public_key.h"
 
-using namespace std::string_literals;
-
 namespace blst_ts {
 
 void P1::Serialize(bool compress, blst::byte *out) const {

--- a/src/secret_key.cc
+++ b/src/secret_key.cc
@@ -1,7 +1,5 @@
 #include "secret_key.h"
 
-using namespace std::string_literals;
-
 namespace blst_ts {
 void SecretKey::Init(
     Napi::Env env, Napi::Object &exports, BlstTsAddon *module) {

--- a/src/secret_key.h
+++ b/src/secret_key.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <memory>
-
 #include "addon.h"
-#include "public_key.h"
-#include "signature.h"
 
 namespace blst_ts {
 static const size_t secret_key_length = 32;

--- a/src/signature.cc
+++ b/src/signature.cc
@@ -1,6 +1,5 @@
 #include "signature.h"
 
-using namespace std::string_literals;
 namespace blst_ts {
 void P2::Serialize(bool compress, blst::byte *out) const {
     compress ? _point.compress(out) : _point.serialize(out);


### PR DESCRIPTION
**Motivations**

When doing the aggregate with randomness PR I noticed a couple of small issues.  In particular the workflow was downloading the bindings with the install command instead of building the new version of the code and unit tests were failing because the new feature was not available in the bindings.

This needs to be handled first so I moved the other small changes over to here for clarity and separation of concerns.

**Description of Changes**
- Update install script to check for `process.env.CI` or `process.env.BLST_TS_FORCE_BUILD` to enforce building of bindings
- Fix `scripts/dev` command (leftover from merging code to master and first time running since)
- Clean up usage of `using std::string_literals`
- Clean up header includes
- Lint code