### PR TITLE
chore: publish 1.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@
 ARG NODE_VERSION
 FROM matthewkeil/blst-ts-armbuild:${NODE_VERSION}
 
+ENV BLST_TS_FORCE_BUILD=true
+
 # NOTE: the artifacts of the build will be placed in /usr/src/blst-ts/prebuild
 #       and that folder should be mounted as a volume when running the container
 WORKDIR /usr/src/blst-ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/blst",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Typescript wrapper for supranational/blst native bindings, a highly performant BLS12-381 signature library",
   "scripts": {
     "install": "ts-node scripts/install",


### PR DESCRIPTION
Trigger publish of 1.0.1.  Will unpublish 1.0.0 for security reasons after this is merged and released

Also has small fix of CI.  Was done for regular build but the ENV variable did not make it into the build containers for the linux-arm64 builds so need to manually pass add it to the `Dockerfile`
https://github.com/ChainSafe/blst-ts/pull/140