### PR TITLE
fix: bits vs bytes in multiplyBy

### DIFF
--- a/src/public_key.cc
+++ b/src/public_key.cc
@@ -18,7 +18,7 @@ blst::P1 P1::MultiplyBy(
     _point.serialize(out);
     // this should get std::move all the way into the P1 member value
     blst::P1 point{out, public_key_length_uncompressed};
-    point.mult(rand_bytes, rand_bytes_length);
+    point.mult(rand_bytes, rand_bytes_length * 8);
     return point;
 }
 
@@ -37,7 +37,7 @@ blst::P1 P1Affine::MultiplyBy(
     _point.serialize(out);
     // this should get std::move all the way into the P1 member value
     blst::P1 point{out, public_key_length_uncompressed};
-    point.mult(rand_bytes, rand_bytes_length);
+    point.mult(rand_bytes, rand_bytes_length * 8);
     return point;
 }
 

--- a/src/signature.cc
+++ b/src/signature.cc
@@ -17,7 +17,7 @@ blst::P2 P2::MultiplyBy(
     _point.serialize(out);
     // this should get std::move all the way into the P2 member value
     blst::P2 point{out, signature_length_uncompressed};
-    point.mult(rand_bytes, rand_bytes_length);
+    point.mult(rand_bytes, rand_bytes_length * 8);
     return point;
 }
 
@@ -45,7 +45,7 @@ blst::P2 P2Affine::MultiplyBy(
     _point.serialize(out);
     // this should get std::move all the way into the P2 member value
     blst::P2 point{out, signature_length_uncompressed};
-    point.mult(rand_bytes, rand_bytes_length);
+    point.mult(rand_bytes, rand_bytes_length * 8);
     return point;
 }
 


### PR DESCRIPTION
When implementing aggregateWithRandomness I found this bug.  Is same as the mult verification bits vs bytes error and can result in invalid verification returning as valid.