### PR TITLE
feat: use crate with MSM and turn on portable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-blst = { path = "blst/bindings/rust" }
+blst = { version = "0.3.13", features = ["portable"] }
 hex = "0.4.3"
 napi = { version = "2.16.8", default-features = false, features = ["napi8"] }
 napi-derive = "2.16.8"


### PR DESCRIPTION
Attempt to fix illegal instruction for celeron.


Perf results from without/with `portable` feature.  Seems like this is a no-brainer thankfully as it looks like its a bit faster on my mac.  Hopefully that will be the same on linux.  Will pull this branch on my vm host and check

```sh
                                                           without portable    with portable
                                                           ================    ================
PublicKey
    ✓ PublicKey serialization                                  1.3572 us/op      1.3216 us/op
    ✓ PublicKey deserialize                                   11.832  us/op     11.4223 us/op
    ✓ PublicKey deserialize and validate - 1 keys             44.2532 us/op     42.2470 us/op
    ✓ PublicKey deserialize and validate - 100 keys            4.4171 ms/op      4.1351 ms/op
    ✓ PublicKey deserialize and validate - 10000 keys        433.5016 ms/op    425.3430 ms/op

SecretKey
    ✓ SecretKey.fromKeygen                                     1.3330 us/op      1.2390 us/op
    ✓ SecretKey serialization                                  1.1740 us/op      1.0820 us/op
    ✓ SecretKey deserialization                                1.0962 us/op      0.9990 us/op
    ✓ SecretKey.toPublicKey                                   72.0770 us/op     71.0530 us/op
    ✓ SecretKey.sign                                         268.6522 us/op    263.9860 us/op

Signature
    ✓ Signature serialization                                  1.2705 us/op      1.2056 us/op
    ✓ Signature deserialize                                   23.1830 us/op     21.9480 us/op
    ✓ Signatures deserialize and validate - 1 sets            60.2580 us/op     60.2580 us/op
    ✓ Signatures deserialize and validate - 100 sets           6.1925 ms/op      6.1075 ms/op
    ✓ Signatures deserialize and validate - 10000 sets       649.4870 ms/op    628.6073 ms/op

functions
    aggregatePublicKeys
        ✓ aggregatePublicKeys - 1 sets                       882.0000 ns/op    860.0000 ns/op
        ✓ aggregatePublicKeys - 8 sets                         6.1750 us/op      6.3503 us/op
        ✓ aggregatePublicKeys - 32 sets                       17.5630 us/op     16.9923 us/op
        ✓ aggregatePublicKeys - 128 sets                      61.4280 us/op     60.0560 us/op
        ✓ aggregatePublicKeys - 256 sets                     119.2770 us/op    119.1583 us/op
    aggregateSignatures
        ✓ aggregateSignatures - 1 sets                       953.0000 ns/op    898.0000 ns/op
        ✓ aggregateSignatures - 8 sets                        11.6060 us/op     10.6923 us/op
        ✓ aggregateSignatures - 32 sets                       36.6710 us/op     35.3333 us/op
        ✓ aggregateSignatures - 128 sets                     136.8770 us/op    135.4700 us/op
        ✓ aggregateSignatures - 256 sets                     279.5440 us/op    271.8913 us/op
    aggregateWithRandomness
        ✓ aggregateWithRandomness - 1 sets                   179.3080 us/op    179.4840 us/op
        ✓ aggregateWithRandomness - 16 sets                    1.2897 ms/op      1.2738 ms/op
        ✓ aggregateWithRandomness - 128 sets                   7.8154 ms/op      7.9330 ms/op
        ✓ aggregateWithRandomness - 256 sets                  15.6922 ms/op     15.5924 ms/op
        ✓ aggregateWithRandomness - 512 sets                  31.6398 ms/op     31.5240 ms/op
        ✓ aggregateWithRandomness - 1024 sets                 62.2136 ms/op     62.3204 ms/op
    aggregateVerify
        ✓ aggregateVerify - 1 sets                           603.3200 us/op    603.0067 us/op
        ✓ aggregateVerify - 8 sets                           717.1630 us/op    728.4093 us/op
        ✓ aggregateVerify - 32 sets                            1.3742 ms/op      1.3936 ms/op
        ✓ aggregateVerify - 128 sets                           4.0280 ms/op      4.0536 ms/op
        ✓ aggregateVerify - 256 sets                           6.7707 ms/op      6.9581 ms/op
    verifyMultipleAggregateSignatures
        ✓ verifyMultipleAggregateSignatures - 1 sets         870.4150 us/op    871.2270 us/op
        ✓ verifyMultipleAggregateSignatures - 8 sets         979.8300 us/op    970.4206 us/op
        ✓ verifyMultipleAggregateSignatures - 32 sets          1.8953 ms/op      1.8857 ms/op
        ✓ verifyMultipleAggregateSignatures - 128 sets         5.1984 ms/op      5.0069 ms/op
        ✓ verifyMultipleAggregateSignatures - 256 sets         9.4786 ms/op      9.3287 ms/op
    verifyMultipleAggregateSignatures same message
        ✓ Same message - 1 sets                              668.8890 us/op    667.0863 us/op
        ✓ Same message - 8 sets                                1.1127 ms/op      1.0993 ms/op
        ✓ Same message - 32 sets                               2.6022 ms/op      2.4810 ms/op
        ✓ Same message - 128 sets                              8.5372 ms/op      8.3003 ms/op
        ✓ Same message - 256 sets                             16.6121 ms/op     16.6121 ms/op
```