### PR TITLE
feat: move to main as the trunk branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 env:
   DEBUG: napi:*
   APP_NAME: blst
-  MACOSX_DEPLOYMENT_TARGET: '10.13'
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
 permissions:
   contents: write
   id-token: write
@@ -11,7 +11,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: '22.4.x'
+          node-version: "22.4.x"
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
-          node-version: '22.4.x'
+          node-version: "22.4.x"
           cache: yarn
           architecture: x86
       - name: Build in docker
@@ -105,7 +105,7 @@ jobs:
         if: ${{ matrix.settings.docker }}
         with:
           image: ${{ matrix.settings.docker }}
-          options: '--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build'
+          options: "--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build"
           run: ${{ matrix.settings.build }}
       - name: Build
         run: ${{ matrix.settings.build }}
@@ -131,8 +131,8 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
         node:
-          - '18'
-          - '22.4.x'
+          - "18"
+          - "22.4.x"
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -167,8 +167,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '18'
-          - '22.4.x'
+          - "18"
+          - "22.4.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '18'
+          - "18"
           - 22.4
     runs-on: ubuntu-latest
     steps:
@@ -234,7 +234,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: node:${{ matrix.node }}-alpine
-          options: '--platform linux/amd64 -v ${{ github.workspace }}:/build -w /build'
+          options: "--platform linux/amd64 -v ${{ github.workspace }}:/build -w /build"
           run: |
             set -e
             yarn test:unit
@@ -250,7 +250,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '18'
+          - "18"
           - 22.4
     runs-on: ubuntu-latest
     steps:
@@ -277,7 +277,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: node:${{ matrix.node }}-slim
-          options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
+          options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build"
           run: |
             set -e
             yarn test:unit
@@ -293,7 +293,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '18'
+          - "18"
           - 22.4
     runs-on: ubuntu-latest
     steps:
@@ -320,7 +320,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: node:${{ matrix.node }}-alpine
-          options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build'
+          options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build"
           run: |
             set -e
             yarn test:unit
@@ -329,7 +329,7 @@ jobs:
             ls -la
 
   publish:
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     name: Publish
     runs-on: ubuntu-latest
     needs:
@@ -343,7 +343,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.4.x'
+          node-version: "22.4.x"
           cache: yarn
       - name: Create tag
         id: tag


### PR DESCRIPTION
All of the rest of our repos have main as the trunk branch.  A bit of cleanup to bring that into alignment.

- switched workflow to run on main

We will need to switch the settings for the repo to memorialize this change.