### PR TITLE
chore: enable trusted publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: "24.x"
+          node-version: "24"
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
@@ -95,7 +95,7 @@ jobs:
         uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
-          node-version: "24.x"
+          node-version: "24"
           cache: yarn
           architecture: x86
       - name: Build in docker
@@ -130,7 +130,7 @@ jobs:
             target: x86_64-pc-windows-msvc
         node:
           - "22"
-          - "24.x"
+          - "24"
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -166,7 +166,7 @@ jobs:
       matrix:
         node:
           - "22"
-          - "24.x"
+          - "24"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -252,7 +252,7 @@ jobs:
       matrix:
         node:
           - "22"
-          - "24.x"
+          - "24"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -294,7 +294,7 @@ jobs:
       matrix:
         node:
           - "22"
-          - "24.x"
+          - "24"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -337,7 +337,7 @@ jobs:
       matrix:
         node:
           - "22"
-          - "24.x"
+          - "24"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,8 +4,9 @@ env:
   APP_NAME: blst
   MACOSX_DEPLOYMENT_TARGET: "10.13"
 permissions:
-  contents: write
-  id-token: write
+  contents: write # Required for OIDC
+  id-token: write # Required to create a Github release
+  pull-requests: write # Required to add tags to pull requests
 
 on:
   pull_request:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -253,7 +253,7 @@ jobs:
       matrix:
         node:
           - "18"
-          - "22.4"
+          - 22.4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -294,8 +294,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22"
-          - "24"
+          - "18"
+          - 22.4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -338,7 +338,7 @@ jobs:
       matrix:
         node:
           - "18"
-          - "22.4"
+          - 22.4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
           # - host: windows-latest
           #   target: aarch64-pc-windows-msvc
           #   build: yarn build --target aarch64-pc-windows-msvc
-    name: Build - ${{ matrix.settings.target }} - node@24
+    name: Build - ${{ matrix.settings.target }} - node@22
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: "24"
+          node-version: "22.4.x"
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
@@ -96,7 +96,7 @@ jobs:
         uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
-          node-version: "24"
+          node-version: "22.4.x"
           cache: yarn
           architecture: x86
       - name: Build in docker
@@ -130,8 +130,8 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
         node:
-          - "22"
-          - "24"
+          - "18"
+          - "22.4.x"
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -166,8 +166,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22"
-          - "24"
+          - "18"
+          - "22.4.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -221,7 +221,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ matrix.bun }}
-      - name: Install deps 
+      - name: Install deps
         run: bun install --frozen-lockfile
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -252,8 +252,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22"
-          - "24"
+          - "18"
+          - "22.4"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -337,8 +337,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22"
-          - "24"
+          - "18"
+          - "22.4"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -388,7 +388,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "24.x"
+          node-version: "22.4.x"
           cache: yarn
       - name: Upgrade npm for OIDC
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
           # - host: windows-latest
           #   target: aarch64-pc-windows-msvc
           #   build: yarn build --target aarch64-pc-windows-msvc
-    name: Build - ${{ matrix.settings.target }} - node@22
+    name: Build - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
-          node-version: "22.4.x"
+          node-version: "24.x"
           cache: yarn
       - name: Install
         uses: dtolnay/rust-toolchain@stable
@@ -95,7 +95,7 @@ jobs:
         uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
-          node-version: "22.4.x"
+          node-version: "24.x"
           cache: yarn
           architecture: x86
       - name: Build in docker
@@ -129,8 +129,8 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
         node:
-          - "18"
-          - "22.4.x"
+          - "22.x"
+          - "24.x"
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -165,8 +165,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "18"
-          - "22.4.x"
+          - "22.x"
+          - "24.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -251,8 +251,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "18"
-          - 22.4
+          - "22.x"
+          - "24.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -293,8 +293,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "18"
-          - 22.4
+          - "22.x"
+          - "24.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -336,8 +336,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "18"
-          - 22.4
+          - "22.x"
+          - "24.x"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -387,7 +387,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.4.x"
+          node-version: "24.x"
           cache: yarn
       - name: Create tag
         id: tag
@@ -418,15 +418,13 @@ jobs:
           npm config set provenance true
           if node -e "console.log(require('./package.json').version)" | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access public
           elif node -e "console.log(require('./package.json').version)" | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
           then
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --tag next --access public
           else
             echo "Not a release, skipping publish"
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -430,4 +430,3 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -389,6 +389,9 @@ jobs:
         with:
           node-version: "24.x"
           cache: yarn
+      - name: Upgrade npm for OIDC
+        if: ${{ steps.release.outputs.releases_created }}
+        run: npm i -g npm@^11.5.1
       - name: Create tag
         id: tag
         uses: butlerlogic/action-autotag@1.1.2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -129,7 +129,7 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
         node:
-          - "22.x"
+          - "22"
           - "24.x"
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -165,7 +165,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22.x"
+          - "22"
           - "24.x"
     runs-on: ubuntu-latest
     steps:
@@ -251,7 +251,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22.x"
+          - "22"
           - "24.x"
     runs-on: ubuntu-latest
     steps:
@@ -293,7 +293,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22.x"
+          - "22"
           - "24.x"
     runs-on: ubuntu-latest
     steps:
@@ -336,7 +336,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - "22.x"
+          - "22"
           - "24.x"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR bumps the CI to utilize node 22/24 and removes the need to pass in NPM token auth. This is part of our migration to utilize trusted publishing and get rid of classic tokens on our CI.